### PR TITLE
Paste markdown text from clipboard

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 import {install as installLink, uninstall as uninstallLink} from './paste-markdown-image-link'
 import {install as installTable, uninstall as uninstallTable} from './paste-markdown-table'
+import {install as installText, uninstall as uninstallText} from './paste-markdown-text'
 
 type Subscription = {|
   unsubscribe: () => void
@@ -10,11 +11,13 @@ type Subscription = {|
 export default function subscribe(el: Element): Subscription {
   installTable(el)
   installLink(el)
+  installText(el)
 
   return {
     unsubscribe: () => {
       uninstallTable(el)
       uninstallLink(el)
+      uninstallText(el)
     }
   }
 }

--- a/src/paste-markdown-text.js
+++ b/src/paste-markdown-text.js
@@ -1,0 +1,31 @@
+/* @flow strict */
+
+import {insertText} from './text'
+
+export function install(el: Element) {
+  el.addEventListener('paste', onPaste)
+}
+
+export function uninstall(el: Element) {
+  el.removeEventListener('paste', onPaste)
+}
+
+function onPaste(event: ClipboardEvent) {
+  const transfer = event.clipboardData
+  if (!transfer || !hasMarkdown(transfer)) return
+
+  const field = event.currentTarget
+  if (!(field instanceof HTMLTextAreaElement)) return
+
+  const text = transfer.getData('text/x-gfm')
+  if (!text) return
+
+  event.stopPropagation()
+  event.preventDefault()
+
+  insertText(field, text)
+}
+
+function hasMarkdown(transfer: DataTransfer): boolean {
+  return Array.from(transfer.types).indexOf('text/x-gfm') >= 0
+}


### PR DESCRIPTION
Pastes markdown formatted text from the clipboard with the custom text/x-gfm mime type if available. Pairs with`@github/quote-selection` which copies the text/x-gfm data onto the clipboard.

/cc https://github.com/github/quote-selection/pull/9