### PR TITLE
Fix pasting a single link in Safari

### DIFF
--- a/src/paste-markdown-image-link.js
+++ b/src/paste-markdown-image-link.js
@@ -21,23 +21,15 @@ function onDrop(event: DragEvent) {
   if (hasFile(transfer)) return
   if (!hasLink(transfer)) return
 
-  let linkified = false
-  const transformedLinks = links(transfer).map(link => {
-    if (isImageLink(link)) {
-      linkified = true
-      return `\n![](${link})\n`
-    } else {
-      return link
-    }
-  })
-  if (!linkified) return
+  const links = extractLinks(transfer)
+  if (!links.some(isImageLink)) return
 
   event.stopPropagation()
   event.preventDefault()
 
   const field = event.currentTarget
   if (!(field instanceof HTMLTextAreaElement)) return
-  insertText(field, transformedLinks.join(''))
+  insertText(field, links.map(linkify).join(''))
 }
 
 function onDragover(event: DragEvent) {
@@ -49,23 +41,19 @@ function onPaste(event: ClipboardEvent) {
   const transfer = event.clipboardData
   if (!transfer || !hasLink(transfer)) return
 
-  let linkified = false
-  const transformedLinks = links(transfer).map(link => {
-    if (isImageLink(link)) {
-      linkified = true
-      return `\n![](${link})\n`
-    } else {
-      return link
-    }
-  })
-  if (!linkified) return
+  const links = extractLinks(transfer)
+  if (!links.some(isImageLink)) return
 
   event.stopPropagation()
   event.preventDefault()
 
   const field = event.currentTarget
   if (!(field instanceof HTMLTextAreaElement)) return
-  insertText(field, transformedLinks.join(''))
+  insertText(field, links.map(linkify).join(''))
+}
+
+function linkify(link: string): string {
+  return isImageLink(link) ? `\n![](${link})\n` : link
 }
 
 function hasFile(transfer: DataTransfer): boolean {
@@ -76,7 +64,7 @@ function hasLink(transfer: DataTransfer): boolean {
   return Array.from(transfer.types).indexOf('text/uri-list') >= 0
 }
 
-function links(transfer: DataTransfer): Array<string> {
+function extractLinks(transfer: DataTransfer): Array<string> {
   return (transfer.getData('text/uri-list') || '').split('\r\n')
 }
 

--- a/src/paste-markdown-image-link.js
+++ b/src/paste-markdown-image-link.js
@@ -80,10 +80,8 @@ function links(transfer: DataTransfer): Array<string> {
   return (transfer.getData('text/uri-list') || '').split('\r\n')
 }
 
+const IMAGE_RE = /\.(gif|png|jpe?g)$/i
+
 function isImageLink(url: string): boolean {
-  const ext = url
-    .split('.')
-    .pop()
-    .toLowerCase()
-  return ['gif', 'png', 'jpg', 'jpeg'].indexOf(ext) > -1
+  return IMAGE_RE.test(url)
 }

--- a/src/paste-markdown-image-link.js
+++ b/src/paste-markdown-image-link.js
@@ -21,15 +21,23 @@ function onDrop(event: DragEvent) {
   if (hasFile(transfer)) return
   if (!hasLink(transfer)) return
 
+  let linkified = false
+  const transformedLinks = links(transfer).map(link => {
+    if (isImageLink(link)) {
+      linkified = true
+      return `\n![](${link})\n`
+    } else {
+      return link
+    }
+  })
+  if (!linkified) return
+
   event.stopPropagation()
   event.preventDefault()
 
   const field = event.currentTarget
   if (!(field instanceof HTMLTextAreaElement)) return
-
-  for (const link of links(transfer).map(linkify)) {
-    insertText(field, link)
-  }
+  insertText(field, transformedLinks.join(''))
 }
 
 function onDragover(event: DragEvent) {
@@ -41,18 +49,23 @@ function onPaste(event: ClipboardEvent) {
   const transfer = event.clipboardData
   if (!transfer || !hasLink(transfer)) return
 
+  let linkified = false
+  const transformedLinks = links(transfer).map(link => {
+    if (isImageLink(link)) {
+      linkified = true
+      return `\n![](${link})\n`
+    } else {
+      return link
+    }
+  })
+  if (!linkified) return
+
   event.stopPropagation()
   event.preventDefault()
 
   const field = event.currentTarget
   if (!(field instanceof HTMLTextAreaElement)) return
-  for (const link of links(transfer).map(linkify)) {
-    insertText(field, link)
-  }
-}
-
-function linkify(link: string): string {
-  return isImageLink(link) ? `\n![](${link})\n` : link
+  insertText(field, transformedLinks.join(''))
 }
 
 function hasFile(transfer: DataTransfer): boolean {

--- a/src/text.js
+++ b/src/text.js
@@ -1,14 +1,15 @@
 /* @flow strict */
 
 export function insertText(textarea: HTMLInputElement | HTMLTextAreaElement, text: string): void {
-  const point = textarea.selectionEnd
-  const beginning = textarea.value.substring(0, point)
-  const remaining = textarea.value.substring(point)
-  const newline = textarea.value === '' || beginning.match(/\n$/) ? '' : '\n'
+  const beginning = textarea.value.substring(0, textarea.selectionStart)
+  const remaining = textarea.value.substring(textarea.selectionEnd)
 
-  textarea.value = beginning + newline + text + remaining
-  textarea.selectionStart = point + text.length
-  textarea.selectionEnd = point + text.length
+  const newline = beginning.length === 0 || beginning.match(/\n$/) ? '' : '\n'
+  const textBeforeCursor = beginning + newline + text
+
+  textarea.value = textBeforeCursor + remaining
+  textarea.selectionStart = textBeforeCursor.length
+  textarea.selectionEnd = textarea.selectionStart
 
   textarea.dispatchEvent(
     new CustomEvent('change', {


### PR DESCRIPTION
- The `paste` & `drop` handlers now fall back to native behavior if no image links were found in the data transfer. This avoids an extra newline when pasting a plain link.
- Do not call `insertText()` more than once. This avoids triggering the 'change' event N times if N items were pasted/dropped.
- Correctly position cursor after operation if extra newline was inserted.
- Correctly replace existing selection on paste.