### PR TITLE
Prevent parsing table[data-paste-markdown-skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Paste Markdown objects
 
-Paste spreadsheet cells as a Markdown table. Convert pasted image URLs to
-Markdown image link syntax.
+- Paste spreadsheet cells and HTML tables as a Markdown tables.
+- Paste image URLs as Markdown image links.
+- *Paste markdown as markdown. See [`@github/quote-selection`/Preserving markdown syntax](https://github.com/github/quote-selection/tree/9ae5f88f5bc3021f51d2dc9981eca83ce7cfe04f#preserving-markdown-syntax) for details.
 
 ## Installation
 
@@ -29,6 +30,16 @@ import subscribe from '@github/paste-markdown'
 
 // Subscribe the behavior to all matching textareas.
 observe('textarea[data-paste-markdown]', {subscribe})
+```
+
+### Excluding `<table>`s
+
+Some `<table>`s are not meant to be pasted as markdown; for example, a file content table with line numbers in a column. Use `data-paste-markdown-skip` to prevent it.
+
+```html
+<table data-paste-markdown-skip>
+  ...
+</table>
 ```
 
 ## Development

--- a/examples/index.html
+++ b/examples/index.html
@@ -29,7 +29,7 @@
     </tbody>
   </table>
 
-  <table border="1" cellpadding="5" class="js-comment">
+  <table border="1" cellpadding="5" data-layout-table>
     <thead>
       <tr>
         <th>name</th>

--- a/examples/index.html
+++ b/examples/index.html
@@ -29,7 +29,7 @@
     </tbody>
   </table>
 
-  <table border="1" cellpadding="5" data-layout-table>
+  <table border="1" cellpadding="5" data-paste-markdown-skip>
     <thead>
       <tr>
         <th>name</th>

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -95,7 +95,7 @@ function parseTable(html: string): HTMLElement | null {
   return el.querySelector('table')
 }
 
-function hasTable(transfer: DataTransfer): HTMLElement | null | void {
+function hasTable(transfer: DataTransfer): HTMLElement | void {
   if (Array.from(transfer.types).indexOf('text/html') === -1) return
 
   const html = transfer.getData('text/html')
@@ -104,8 +104,8 @@ function hasTable(transfer: DataTransfer): HTMLElement | null | void {
   const table = parseTable(html)
   if (!table) return
 
-  // Edge copies the surrounding table from our issue comment text.
-  if (table.closest('.js-comment')) return
+  // Prevent pasting layout table
+  if (table.closest('[data-layout-table]')) return
 
-  return /\b(js|blob|diff)-./.test(table.className) ? null : table
+  return table
 }

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -105,7 +105,7 @@ function hasTable(transfer: DataTransfer): HTMLElement | void {
   if (!table) return
 
   // Prevent pasting layout table
-  if (table.closest('[data-layout-table]')) return
+  if (table.closest('[data-paste-markdown-skip]')) return
 
   return table
 }

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -95,17 +95,12 @@ function parseTable(html: string): HTMLElement | null {
   return el.querySelector('table')
 }
 
-function hasTable(transfer: DataTransfer): HTMLElement | void {
-  if (Array.from(transfer.types).indexOf('text/html') === -1) return
+function hasTable(transfer: DataTransfer): HTMLElement | null {
+  if (Array.from(transfer.types).indexOf('text/html') === -1) return null
 
   const html = transfer.getData('text/html')
-  if (!/<table/i.test(html)) return
+  if (!/<table/i.test(html)) return null
 
   const table = parseTable(html)
-  if (!table) return
-
-  // Prevent pasting layout table
-  if (table.closest('[data-paste-markdown-skip]')) return
-
-  return table
+  return !table || table.closest('[data-paste-markdown-skip]') ? null : table
 }

--- a/test/test.js
+++ b/test/test.js
@@ -41,7 +41,7 @@ describe('paste-markdown', function() {
     it('rejects layout tables', function() {
       const data = {
         'text/html': `
-        <table data-layout-table>
+        <table data-paste-markdown-skip>
           <thead><tr><th>name</th><th>origin</th></tr></thead>
           <tbody>
             <tr><td>hubot</td><td>github</td></tr>

--- a/test/test.js
+++ b/test/test.js
@@ -38,10 +38,10 @@ describe('paste-markdown', function() {
       assert.include(textarea.value, 'name | origin\n-- | --\nhubot | github\nbender | futurama')
     })
 
-    it('rejects HTML from github.com markup', function() {
+    it('rejects layout tables', function() {
       const data = {
         'text/html': `
-        <table class="js-comment">
+        <table data-layout-table>
           <thead><tr><th>name</th><th>origin</th></tr></thead>
           <tbody>
             <tr><td>hubot</td><td>github</td></tr>


### PR DESCRIPTION
In dotcom we use `<table>` for as HTML parser boundaries in comments and for line/column in blobs. These tables should not be turned into markdown tables when they get copy-pasted.

Previously we use `js-comment`/`js-blob-*`/`js-diff-*` as pointers to skip certain tables. This PR generalize them so it will be easier to mark future tables as not pastable as markdown without altering the library code or subscribing them into `js-` prefixed classes.

I was gonna call this `[data-layout-table]` but opted to name it `[data-paste-markdown-skip]` instead because:

1. I thought "layout tables" was fitting because they are tables used for their display characteristics instead of semantics, hence should not be parsed as tables. But turns out, many of our cases are actual data tables that just aren't supposed to be turned into markdown.
2. Prefixing with `paste-markdown` to make it's clear to see the attribute came from a library.