### PR TITLE
Retain other text around HTML tables

### DIFF
--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -95,5 +95,5 @@ function generateText(transfer: DataTransfer): string | undefined {
 
   const formattedTable = tableMarkdown(table)
 
-  return html.replace(/<meta.*?>/, '').replace(/<table.*<\/table>/, `\n${formattedTable}`)
+  return html.replace(/<meta.*?>/, '').replace(/<table[.\S\s]*<\/table>/, `\n${formattedTable}`)
 }

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -85,7 +85,16 @@ function tableMarkdown(node: Element): string {
 function parseTable(html: string): HTMLElement | null {
   const el = document.createElement('div')
   el.innerHTML = html
-  return el.querySelector('table')
+
+  const table = el.querySelector('table')
+  table?.remove()
+
+  // Reject tables that have extra text around them.
+  if (el?.textContent?.trim()) {
+    return null
+  }
+
+  return table
 }
 
 function getTable(transfer: DataTransfer): HTMLElement | null {

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -20,7 +20,7 @@ function onDrop(event: DragEvent) {
 
   if (hasFile(transfer)) return
 
-  const table = hasTable(transfer)
+  const table = getTable(transfer)
   if (!table) return
 
   event.stopPropagation()
@@ -40,7 +40,7 @@ function onDragover(event: DragEvent) {
 function onPaste(event: ClipboardEvent) {
   if (!event.clipboardData) return
 
-  const table = hasTable(event.clipboardData)
+  const table = getTable(event.clipboardData)
   if (!table) return
 
   event.stopPropagation()
@@ -90,7 +90,7 @@ function parseTable(html: string): HTMLElement | null {
   return el.querySelector('table')
 }
 
-function hasTable(transfer: DataTransfer): HTMLElement | null {
+function getTable(transfer: DataTransfer): HTMLElement | null {
   if (Array.from(transfer.types).indexOf('text/html') === -1) return null
 
   const html = transfer.getData('text/html')

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -1,5 +1,3 @@
-/* @flow strict */
-
 import {insertText} from './text'
 
 export function install(el: HTMLElement): void {

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -15,18 +15,17 @@ export function uninstall(el: HTMLElement): void {
 function onDrop(event: DragEvent) {
   const transfer = event.dataTransfer
   if (!transfer) return
-
   if (hasFile(transfer)) return
 
-  const table = getTable(transfer)
-  if (!table) return
+  const textToPaste = generateText(transfer)
+  if (!textToPaste) return
 
   event.stopPropagation()
   event.preventDefault()
 
   const field = event.currentTarget
   if (field instanceof HTMLTextAreaElement) {
-    insertText(field, tableMarkdown(table))
+    insertText(field, textToPaste)
   }
 }
 
@@ -38,15 +37,15 @@ function onDragover(event: DragEvent) {
 function onPaste(event: ClipboardEvent) {
   if (!event.clipboardData) return
 
-  const table = getTable(event.clipboardData)
-  if (!table) return
+  const textToPaste = generateText(event.clipboardData)
+  if (!textToPaste) return
 
   event.stopPropagation()
   event.preventDefault()
 
   const field = event.currentTarget
   if (field instanceof HTMLTextAreaElement) {
-    insertText(field, tableMarkdown(table))
+    insertText(field, textToPaste)
   }
 }
 
@@ -82,27 +81,19 @@ function tableMarkdown(node: Element): string {
   return `\n${header}${body}\n\n`
 }
 
-function parseTable(html: string): HTMLElement | null {
-  const el = document.createElement('div')
-  el.innerHTML = html
-
-  const table = el.querySelector('table')
-  table?.remove()
-
-  // Reject tables that have extra text around them.
-  if (el?.textContent?.trim()) {
-    return null
-  }
-
-  return table
-}
-
-function getTable(transfer: DataTransfer): HTMLElement | null {
-  if (Array.from(transfer.types).indexOf('text/html') === -1) return null
+function generateText(transfer: DataTransfer): string | undefined {
+  if (Array.from(transfer.types).indexOf('text/html') === -1) return
 
   const html = transfer.getData('text/html')
-  if (!/<table/i.test(html)) return null
+  if (!/<table/i.test(html)) return
 
-  const table = parseTable(html)
-  return !table || table.closest('[data-paste-markdown-skip]') ? null : table
+  const el = document.createElement('div')
+  el.innerHTML = html
+  let table = el.querySelector('table')
+  table = !table || table.closest('[data-paste-markdown-skip]') ? null : table
+  if (!table) return
+
+  const formattedTable = tableMarkdown(table)
+
+  return html.replace(/<meta.*?>/, '').replace(/<table.*<\/table>/, `\n${formattedTable}`)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -53,10 +53,12 @@ describe('paste-markdown', function () {
         `
       }
 
-      // Synthetic paste events don't manipulate the DOM. A empty textarea
-      // means that the event handler didn't fire and normal paste happened.
       paste(textarea, data)
-      assert.equal(textarea.value, '')
+      assert.equal(
+        textarea.value.trim(),
+        // eslint-disable-next-line github/unescaped-html-literal
+        '<p>Here is a cool table</p>\n        \n\nname | origin\n-- | --\nhubot | github\nbender | futurama\n\n\n        <p>Very cool</p>'
+      )
     })
 
     it('rejects layout tables', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -38,7 +38,7 @@ describe('paste-markdown', function () {
       assert.include(textarea.value, 'name | origin\n-- | --\nhubot | github\nbender | futurama')
     })
 
-    it('rejects tables with extra text', async function () {
+    it('retains text around tables', async function () {
       const data = {
         'text/html': `
         <p>Here is a cool table</p>

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,27 @@ describe('paste-markdown', function () {
       assert.include(textarea.value, 'name | origin\n-- | --\nhubot | github\nbender | futurama')
     })
 
+    it('rejects tables with extra text', async function () {
+      const data = {
+        'text/html': `
+        <p>Here is a cool table</p>
+        <table>
+          <thead><tr><th>name</th><th>origin</th></tr></thead>
+          <tbody>
+            <tr><td>hubot</td><td>github</td></tr>
+            <tr><td>bender</td><td>futurama</td></tr>
+          </tbody>
+        </table>
+        <p>Very cool</p>
+        `
+      }
+
+      // Synthetic paste events don't manipulate the DOM. A empty textarea
+      // means that the event handler didn't fire and normal paste happened.
+      paste(textarea, data)
+      assert.equal(textarea.value, '')
+    })
+
     it('rejects layout tables', function () {
       const data = {
         'text/html': `
@@ -51,6 +72,9 @@ describe('paste-markdown', function () {
         `
       }
       paste(textarea, data)
+
+      // Synthetic paste events don't manipulate the DOM. A empty textarea
+      // means that the event handler didn't fire and normal paste happened.
       assert.equal(textarea.value, '')
     })
 


### PR DESCRIPTION
Before this change, we would fish out the table element from the pasted value, convert that into a markdown table, and inject that markdown table into the textarea element.

After the change in this pull request, we will retain the original text and only replace the HTML table.