### PR TITLE
Add pasting URLs on selected text as Markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Paste Markdown objects
 
 - Paste spreadsheet cells and HTML tables as a Markdown tables.
+- Paste URLs on selected text as Markdown links.
 - Paste image URLs as Markdown image links.
 - Paste markdown as markdown. See [`@github/quote-selection`/Preserving markdown syntax](https://github.com/github/quote-selection/tree/9ae5f88f5bc3021f51d2dc9981eca83ce7cfe04f#preserving-markdown-syntax) for details.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm install @github/paste-markdown
 ## Usage
 
 ```js
-import subscribe from '@github/paste-markdown'
+import {subscribe} from '@github/paste-markdown'
 
 // Subscribe the behavior to the textarea.
 subscribe(document.querySelector('textarea[data-paste-markdown]'))
@@ -27,7 +27,7 @@ be applied to any element matching a selector.
 
 ```js
 import {observe} from 'selector-observer'
-import subscribe from '@github/paste-markdown'
+import {subscribe} from '@github/paste-markdown'
 
 // Subscribe the behavior to all matching textareas.
 observe('textarea[data-paste-markdown]', {subscribe})

--- a/examples/index.html
+++ b/examples/index.html
@@ -51,8 +51,8 @@
   <textarea cols="50" rows="10">The examples can be found here.</textarea>
 
   <script type="module">
-    // import {subscribe, installLink} from '../dist/index.esm.js'
-    import {subscribe, installLink} from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
+    // import {subscribe} from '../dist/index.esm.js'
+    import {subscribe} from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
     subscribe(document.querySelector('textarea'))
     installLink(document.querySelector('textarea'))
   </script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -51,9 +51,10 @@
   <textarea cols="50" rows="10">The examples can be found here.</textarea>
 
   <script type="module">
-    // import subscribe from '../dist/index.esm.js'
-    import subscribe from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
+    // import {subscribe, installLink} from '../dist/index.esm.js'
+    import {subscribe, installLink} from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
     subscribe(document.querySelector('textarea'))
+    installLink(document.querySelector('textarea'))
   </script>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -46,7 +46,9 @@
 
   <img src="https://github.com/hubot.png" width="100" alt="hubot">
 
-  <textarea cols="50" rows="10"></textarea>
+  <p>Test by copying this page's URL and then selecting <i>here</i> in the textarea and pasting the URL.</p>
+
+  <textarea cols="50" rows="10">The examples can be found here.</textarea>
 
   <script type="module">
     // import subscribe from '../dist/index.esm.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,14 @@ interface Subscription {
 function subscribe(el: HTMLElement): Subscription {
   installTable(el)
   installImageLink(el)
+  installLink(el)
   installText(el)
 
   return {
     unsubscribe: () => {
       uninstallTable(el)
       uninstallImageLink(el)
+      uninstallLink(el)
       uninstallText(el)
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,18 +7,28 @@ interface Subscription {
   unsubscribe: () => void
 }
 
-export default function subscribe(el: HTMLElement): Subscription {
+function subscribe(el: HTMLElement): Subscription {
   installTable(el)
   installImageLink(el)
-  installLink(el)
   installText(el)
 
   return {
     unsubscribe: () => {
       uninstallTable(el)
       uninstallImageLink(el)
-      uninstallLink(el)
       uninstallText(el)
     }
   }
+}
+
+export {
+  subscribe,
+  installImageLink,
+  installLink,
+  installTable,
+  installText,
+  uninstallImageLink,
+  uninstallTable,
+  uninstallLink,
+  uninstallText
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import {install as installLink, uninstall as uninstallLink} from './paste-markdown-image-link'
+import {install as installImageLink, uninstall as uninstallImageLink} from './paste-markdown-image-link'
+import {install as installLink, uninstall as uninstallLink} from './paste-markdown-link'
 import {install as installTable, uninstall as uninstallTable} from './paste-markdown-table'
 import {install as installText, uninstall as uninstallText} from './paste-markdown-text'
 
@@ -8,12 +9,14 @@ interface Subscription {
 
 export default function subscribe(el: HTMLElement): Subscription {
   installTable(el)
+  installImageLink(el)
   installLink(el)
   installText(el)
 
   return {
     unsubscribe: () => {
       uninstallTable(el)
+      uninstallImageLink(el)
       uninstallLink(el)
       uninstallText(el)
     }

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -1,0 +1,54 @@
+import {insertText} from './text'
+
+export function install(el: HTMLElement): void {
+  el.addEventListener('paste', onPaste)
+}
+
+export function uninstall(el: HTMLElement): void {
+  el.removeEventListener('paste', onPaste)
+}
+
+function onPaste(event: ClipboardEvent) {
+  const transfer = event.clipboardData
+  if (!transfer || !hasPlainText(transfer)) return
+
+  const field = event.currentTarget
+  if (!(field instanceof HTMLTextAreaElement)) return
+
+  const text = transfer.getData('text/plain')
+  if (!text) return
+
+  if (isWithinLink(field)) return
+
+  event.stopPropagation()
+  event.preventDefault()
+
+  const selectedText = field.value.substring(field.selectionStart, field.selectionEnd)
+
+  insertText(field, linkify(selectedText, text), false)
+}
+
+function hasPlainText(transfer: DataTransfer): boolean {
+  return Array.from(transfer.types).indexOf('text/plain') >= 0
+}
+
+function isWithinLink(textarea: HTMLTextAreaElement): boolean {
+  const selectionStart = textarea.selectionStart || 0
+
+  if (selectionStart > 1) {
+    const previousChars = textarea.value.substring(selectionStart - 2, selectionStart)
+    return previousChars === ']('
+  } else {
+    return false
+  }
+}
+
+function linkify(selectedText: string, text: string): string {
+  return selectedText.length && isURL(text) ? `[${selectedText}](${text})` : text
+}
+
+const URL_RE = /^https?:\/\//i
+
+function isURL(url: string): boolean {
+  return URL_RE.test(url)
+}

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -47,8 +47,6 @@ function linkify(selectedText: string, text: string): string {
   return selectedText.length && isURL(text) ? `[${selectedText}](${text})` : text
 }
 
-const URL_RE = /^https?:\/\//i
-
 function isURL(url: string): boolean {
-  return URL_RE.test(url)
+  return /^https?:\/\//i.test(url)
 }

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -25,7 +25,7 @@ function onPaste(event: ClipboardEvent) {
 
   const selectedText = field.value.substring(field.selectionStart, field.selectionEnd)
 
-  insertText(field, linkify(selectedText, text), false)
+  insertText(field, linkify(selectedText, text), {addNewline: false})
 }
 
 function hasPlainText(transfer: DataTransfer): boolean {

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -29,7 +29,7 @@ function onPaste(event: ClipboardEvent) {
 }
 
 function hasPlainText(transfer: DataTransfer): boolean {
-  return Array.from(transfer.types).indexOf('text/plain') >= 0
+  return Array.from(transfer.types).includes('text/plain')
 }
 
 function isWithinLink(textarea: HTMLTextAreaElement): boolean {

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,8 +1,12 @@
-export function insertText(textarea: HTMLInputElement | HTMLTextAreaElement, text: string, addNewline = true): void {
+export function insertText(
+  textarea: HTMLInputElement | HTMLTextAreaElement,
+  text: string,
+  options = {addNewline: true}
+): void {
   const beginning = textarea.value.substring(0, textarea.selectionStart || 0)
   const remaining = textarea.value.substring(textarea.selectionEnd || 0)
 
-  const newline = !addNewline || beginning.length === 0 || beginning.match(/\n$/) ? '' : '\n'
+  const newline = !options.addNewline || beginning.length === 0 || beginning.match(/\n$/) ? '' : '\n'
   const textBeforeCursor = beginning + newline + text
 
   textarea.value = textBeforeCursor + remaining

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,8 +1,8 @@
-export function insertText(textarea: HTMLInputElement | HTMLTextAreaElement, text: string): void {
+export function insertText(textarea: HTMLInputElement | HTMLTextAreaElement, text: string, addNewline = true): void {
   const beginning = textarea.value.substring(0, textarea.selectionStart || 0)
   const remaining = textarea.value.substring(textarea.selectionEnd || 0)
 
-  const newline = beginning.length === 0 || beginning.match(/\n$/) ? '' : '\n'
+  const newline = !addNewline || beginning.length === 0 || beginning.match(/\n$/) ? '' : '\n'
   const textBeforeCursor = beginning + newline + text
 
   textarea.value = textBeforeCursor + remaining

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {subscribe, installLink, uninstallLink} from '../dist/index.esm.js'
+import {subscribe} from '../dist/index.esm.js'
 
 describe('paste-markdown', function () {
   describe('installed on textarea', function () {
@@ -11,12 +11,10 @@ describe('paste-markdown', function () {
 
       textarea = document.querySelector('textarea[data-paste-markdown]')
       subscription = subscribe(textarea)
-      installLink(textarea)
     })
 
     afterEach(function () {
       subscription.unsubscribe()
-      uninstallLink(textarea)
       document.body.innerHTML = ''
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -24,6 +24,7 @@ describe('paste-markdown', function () {
     })
 
     it('turns pasted urls on selected text into markdown links', function () {
+      // eslint-disable-next-line i18n-text/no-en
       textarea.value = 'The examples can be found here.'
       textarea.setSelectionRange(26, 30)
       paste(textarea, {'text/plain': 'https://github.com'})

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,13 @@ describe('paste-markdown', function () {
       assert.include(textarea.value, '![](https://github.com/github.png)\n\n![](https://github.com/hubot.png)')
     })
 
+    it('turns pasted urls on selected text into markdown links', function () {
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      paste(textarea, {'text/plain': 'https://github.com'})
+      assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
+    })
+
     it('turns html tables into markdown', function () {
       const data = {
         'text/html': `

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import subscribe from '../dist/index.esm.js'
+import {subscribe, installLink, uninstallLink} from '../dist/index.esm.js'
 
 describe('paste-markdown', function () {
   describe('installed on textarea', function () {
@@ -10,10 +10,12 @@ describe('paste-markdown', function () {
 
       textarea = document.querySelector('textarea[data-paste-markdown]')
       subscription = subscribe(textarea)
+      installLink(textarea)
     })
 
     afterEach(function () {
       subscription.unsubscribe()
+      uninstallLink(textarea)
       document.body.innerHTML = ''
     })
 


### PR DESCRIPTION
This pull request adds pasting URLs on selected text as Markdown links.

In order to test this new functionality:
1. Copy this URL `https://docs.github.com` or any other URL
1. Go to https://paste-markdown-steffen-testing.vercel.app/examples
1. Write something like: `You can find the docs here.`
1. Select `here`
1. Paste URL with <kbd>cmd + v</kbd>

Result: You should now see a Markdown link: `[here](https://docs.github.com)`