### PR TITLE
Make `Build` workflow run for PRs from forked repos

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Build` workflow for [this PR](https://github.com/github/paste-markdown/pull/23) is not running as I opened it from a forked repository (since I don't have write permissions to this repository) and since the workflow only listens for `push` events.
This PR should fix this and make the `Build` workflow run for [`pull_request` `opened`, `synchronize` and `reopened` events](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request).

![image](https://user-images.githubusercontent.com/6301/134931225-150f31f6-d5ea-40f6-b259-c11ac5ddf36e.png)


