### PR TITLE
Include all `dist` files in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   ],
   "license": "MIT",
   "files": [
-    "dist/index.d.ts",
-    "dist/index.esm.js",
-    "dist/index.umd.js"
+    "dist/*"
   ],
   "prettier": "@github/prettier-config",
   "devDependencies": {


### PR DESCRIPTION
Our `tsc` in `github/github` complains about missing type declarations:

```
node_modules/@github/paste-markdown/dist/index.d.ts(1,78): error TS2307: Cannot find module './paste-markdown-image-link' or its corresponding type declarations.

node_modules/@github/paste-markdown/dist/index.d.ts(2,68): error TS2307: Cannot find module './paste-markdown-link' or its corresponding type declarations.

node_modules/@github/paste-markdown/dist/index.d.ts(3,70): error TS2307: Cannot find module './paste-markdown-table' or its corresponding type declarations.

node_modules/@github/paste-markdown/dist/index.d.ts(4,68): error TS2307: Cannot find module './paste-markdown-text' or its corresponding type declarations.
```

This PR should resolve this.

Not sure if you have a preference for listing each file explicitly or if you are ok with `dist/*`?

The wildcard will also include `text.d.ts` while I believe only the following files are needed additionally to the existing `files` values:
```
paste-markdown-image-link.d.ts
paste-markdown-link.d.ts
paste-markdown-table.d.ts
paste-markdown-text.d.ts
```