### PR TITLE
Add "undo" support

### DIFF
--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -25,7 +25,7 @@ function onPaste(event: ClipboardEvent) {
 
   const selectedText = field.value.substring(field.selectionStart, field.selectionEnd)
 
-  insertText(field, linkify(selectedText, text), {addNewline: false})
+  insertText(field, linkify(selectedText, text))
 }
 
 function hasPlainText(transfer: DataTransfer): boolean {

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,24 +1,33 @@
-export function insertText(
-  textarea: HTMLInputElement | HTMLTextAreaElement,
-  text: string,
-  options = {addNewline: true}
-): void {
-  const beginning = textarea.value.substring(0, textarea.selectionStart || 0)
-  const remaining = textarea.value.substring(textarea.selectionEnd || 0)
+export function insertText(textarea: HTMLInputElement | HTMLTextAreaElement, text: string): void {
+  const before = textarea.value.slice(0, textarea.selectionStart || undefined)
+  const after = textarea.value.slice(textarea.selectionEnd || undefined)
 
-  const newline = !options.addNewline || beginning.length === 0 || beginning.match(/\n$/) ? '' : '\n'
-  const textBeforeCursor = beginning + newline + text
+  let canInsertText = true
 
-  textarea.value = textBeforeCursor + remaining
-  textarea.selectionStart = textBeforeCursor.length
-  textarea.selectionEnd = textarea.selectionStart
+  textarea.contentEditable = 'true'
+  try {
+    canInsertText = document.execCommand('insertText', false, text)
+  } catch (error) {
+    canInsertText = false
+  }
+  textarea.contentEditable = 'false'
 
-  textarea.dispatchEvent(
-    new CustomEvent('change', {
-      bubbles: true,
-      cancelable: false
-    })
-  )
+  if (canInsertText && !textarea.value.slice(0, textarea.selectionStart || undefined).endsWith(text)) {
+    canInsertText = false
+  }
 
-  textarea.focus()
+  if (!canInsertText) {
+    try {
+      document.execCommand('ms-beginUndoUnit')
+    } catch (e) {
+      // Do nothing.
+    }
+    textarea.value = before + text + after
+    try {
+      document.execCommand('ms-endUndoUnit')
+    } catch (e) {
+      // Do nothing.
+    }
+    textarea.dispatchEvent(new CustomEvent('input', {bubbles: true, cancelable: true}))
+  }
 }


### PR DESCRIPTION
All pastes that are modified by `@github/paste-markdown` can currently not be undone by pressing <kbd>cmd</kbd> + <kbd>z</kbd> (on Mac) or by clicking `Undo` in the textarea's context menu.

This seems to not have been an issue so far for the existing functionality such as pasting a table or dragging an image URL into a textarea.

For the [new linkify feature](https://github.com/github/paste-markdown/pull/23) we expect this to be a more obvious and annoying issue, either when users select accidentally the wrong text, or when they actually expect to replace text with an URL or when they just want to play/test with the new functionality.

The reason for the missing "undo" support is that the current implementation uses `textarea.value = 'value'`.
The only way that I know of supporting the "undo" functionality is by using `document.execCommand('insertText'`).

Unfortunately `document.execCommand` [seems to be deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand).
Though, we are using it in our `@github/markdown-toolbar-element` library:
https://github.com/github/markdown-toolbar-element/blob/a5b444a0405348be2af01535a8b594147370dc4b/src/index.ts#L379-L418

I copied the implementation of the `markdown-toolbar-element` implementation mostly as is and it seems to work flawlessly in my testing.

I know "copying" an implementation from another source instead of reusing it is not ideal.
I also know that using a deprecated API is not ideal.
Though, I don't have any better ideas for adding "undo" support to `@github/paste-markdown`.
What do you think @github/ui-frameworks?