### PR TITLE
Only run linkify for URLs

### DIFF
--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -17,13 +17,14 @@ function onPaste(event: ClipboardEvent) {
 
   const text = transfer.getData('text/plain')
   if (!text) return
-
+  if (!isURL(text)) return
   if (isWithinLink(field)) return
+
+  const selectedText = field.value.substring(field.selectionStart, field.selectionEnd)
+  if (!selectedText.length) return
 
   event.stopPropagation()
   event.preventDefault()
-
-  const selectedText = field.value.substring(field.selectionStart, field.selectionEnd)
 
   insertText(field, linkify(selectedText, text), {addNewline: false})
 }
@@ -44,7 +45,7 @@ function isWithinLink(textarea: HTMLTextAreaElement): boolean {
 }
 
 function linkify(selectedText: string, text: string): string {
-  return selectedText.length && isURL(text) ? `[${selectedText}](${text})` : text
+  return `[${selectedText}](${text})`
 }
 
 function isURL(url: string): boolean {


### PR DESCRIPTION
Right now all pastes go through the [new linkify functionality](https://github.com/github/paste-markdown/pull/23).

This causes that pasting a HTML table inserts a Markdown table _and_ the plain text table.
It currently also breaks the "undo" functionality for all pastes (which would be fixed by [this PR](https://github.com/github/paste-markdown/pull/28)).

This PR tightens the conditions for running the actual linkify function to only pastes with an URL in the clipboard and to only pastes where text is selected.