### PR TITLE
Remove `installLink` from examples page

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -54,7 +54,6 @@
     // import {subscribe} from '../dist/index.esm.js'
     import {subscribe} from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
     subscribe(document.querySelector('textarea'))
-    installLink(document.querySelector('textarea'))
   </script>
 </body>
 </html>


### PR DESCRIPTION
It was a left over from the API changes where `installLink` was not in the `subscribe` method