### PR TITLE
Fix Microsoft Edge link paste

### DIFF
--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -83,8 +83,8 @@ function hasHTML(transfer: DataTransfer): boolean {
   return transfer.types.includes('text/html')
 }
 
-function hasLinkPreview(transfer) {
-  return transfer.types.includes('text/link-preview');
+function hasLinkPreview(transfer: DataTransfer): boolean {
+  return transfer.types.includes('text/link-preview')
 }
 
 function linkify(element: HTMLAnchorElement): string {

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -12,7 +12,11 @@ type MarkdownTransformer = (element: HTMLElement | HTMLAnchorElement, args: stri
 
 function onPaste(event: ClipboardEvent) {
   const transfer = event.clipboardData
-  if (!transfer || !hasHTML(transfer)) return
+  // if there is no clipboard data, or
+  // if there is no html content in the clipboard, or
+  // if the browser has made an "improved URL for pasting", return
+  // See https://support.microsoft.com/en-gb/microsoft-edge/improved-copy-and-paste-of-urls-in-microsoft-edge-d3bd3956-603a-0033-1fbc-9588a30645b4 for more
+  if (!transfer || !hasHTML(transfer) || hasLinkPreview(transfer)) return
 
   const field = event.currentTarget
   if (!(field instanceof HTMLTextAreaElement)) return
@@ -77,6 +81,10 @@ function trimAfter(text: string, search = ''): {part: string; index: number} {
 
 function hasHTML(transfer: DataTransfer): boolean {
   return transfer.types.includes('text/html')
+}
+
+function hasLinkPreview(transfer) {
+  return transfer.types.includes('text/link-preview');
 }
 
 function linkify(element: HTMLAnchorElement): string {


### PR DESCRIPTION
## Summary

Hello! After #35, I discovered that this feature does not work on Microsoft Edge due to [Improved copy and paste of URLs in Microsoft Edge](https://support.microsoft.com/en-us/microsoft-edge/improved-copy-and-paste-of-urls-in-microsoft-edge-d3bd3956-603a-0033-1fbc-9588a30645b4). This pull request brings the functionality of #35 to Microsoft Edge.

Full support for [Improved copy and paste of URLs in Microsoft Edge](https://support.microsoft.com/en-us/microsoft-edge/improved-copy-and-paste-of-urls-in-microsoft-edge-d3bd3956-603a-0033-1fbc-9588a30645b4) would come in a subsequent PR.

Thanks for taking a look!