### PR TITLE
Fix: target correct link when multiple matches are present

### DIFF
--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -48,7 +48,7 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
   let markdown = plaintext
   let markdownIgnoreBeforeIndex = 0
   let index = 0
-  const NODE_LIMIT = 100000
+  const NODE_LIMIT = 10000
 
   // Walk through the DOM tree
   while (currentNode && index < NODE_LIMIT) {

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -53,9 +53,7 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
   // Walk through the DOM tree
   while (currentNode && index < NODE_LIMIT) {
     index++
-    const text = isLink(currentNode)
-      ? currentNode.textContent || ''
-      : (currentNode.firstChild as Text)?.wholeText || ''
+    const text = isLink(currentNode) ? currentNode.textContent || '' : (currentNode.firstChild as Text)?.wholeText || ''
 
     // No need to transform whitespace
     if (isEmptyString(text)) {

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -90,7 +90,7 @@ function isEmptyString(text: string): boolean {
   return !text || text?.trim().length === 0
 }
 
-function isLink(node: HTMLElement): boolean {
+function isLink(node: HTMLElement): node is HTMLAnchorElement {
   return node.tagName.toLowerCase() === 'a' && node.hasAttribute('href')
 }
 

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -44,7 +44,7 @@ function onPaste(event: ClipboardEvent) {
 }
 
 function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
-  let currentNode = walker.firstChild() as HTMLAnchorElement | HTMLElement | null
+  let currentNode = walker.firstChild()
   let markdown = plaintext
   let markdownIgnoreBeforeIndex = 0
   let index = 0
@@ -54,12 +54,12 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
   while (currentNode && index < NODE_LIMIT) {
     index++
     const text = isLink(currentNode)
-      ? (currentNode as HTMLAnchorElement).textContent || ''
+      ? currentNode.textContent || ''
       : (currentNode.firstChild as Text)?.wholeText || ''
 
     // No need to transform whitespace
     if (isEmptyString(text)) {
-      currentNode = walker.nextNode() as HTMLAnchorElement | HTMLElement | null
+      currentNode = walker.nextNode()
       continue
     }
 
@@ -68,7 +68,7 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
 
     if (markdownFoundIndex >= 0) {
       if (isLink(currentNode)) {
-        const markdownLink = linkify(currentNode as HTMLAnchorElement)
+        const markdownLink = linkify(currentNode)
         // Transform 'example link plus more text' into 'example [link](example link) plus more text'
         // Method: 'example [link](example link) plus more text' = 'example ' + '[link](example link)' + ' plus more text'
         markdown =
@@ -79,7 +79,7 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
       }
     }
 
-    currentNode = walker.nextNode() as HTMLAnchorElement | HTMLElement | null
+    currentNode = walker.nextNode()
   }
 
   // Unless we hit the node limit, we should have processed all nodes
@@ -90,8 +90,8 @@ function isEmptyString(text: string): boolean {
   return !text || text?.trim().length === 0
 }
 
-function isLink(node: HTMLElement): node is HTMLAnchorElement {
-  return node.tagName.toLowerCase() === 'a' && node.hasAttribute('href')
+function isLink(node: Node): node is HTMLAnchorElement {
+  return (node as HTMLElement).tagName?.toLowerCase() === 'a' && (node as HTMLElement).hasAttribute('href')
 }
 
 function hasHTML(transfer: DataTransfer): boolean {

--- a/test/test.js
+++ b/test/test.js
@@ -132,10 +132,10 @@ describe('paste-markdown', function () {
 
     it('turns mixed html content containing several links into appropriate markdown', function () {
       // eslint-disable-next-line github/unescaped-html-literal
-      const sentence = `<meta charset='utf-8'><meta charset="utf-8">
+      const sentence = `<meta charset='utf-8'>
         <b style="font-weight:normal;"><p dir="ltr"><span>This is a </span>
-        <a href="https://github.com/"><span>link</span></a><span> and </span>
-        <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"><span>another link</span></a></p>
+        <a href="https://github.com/">link</a><span> and </span>
+        <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">another link</a></p>
         <br /><a href="https://github.com/"><span>Link</span></a><span> at the beginning, link at the </span>
         <a href="https://github.com/"><span>end</span></a></b>`
       // eslint-disable-next-line i18n-text/no-en
@@ -186,19 +186,29 @@ describe('paste-markdown', function () {
 
     it('leaves plaintext links alone', function () {
       // eslint-disable-next-line github/unescaped-html-literal
-      const sentence = `<meta charset='utf-8'><meta charset="utf-8">
+      const sentence = `<meta charset='utf-8'>
         <b style="font-weight:normal;"><p dir="ltr"><span>This is a </span>
-        <a href="https://github.com/"><span>https://github.com</span></a><span> and </span>
-        <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"><span>another link</span></a></p>
-        <br /><a href="https://github.com/"><span>Link</span></a><span> at the beginning, link at the </span>
-        <a href="https://github.com/"><span>https://github.com/</span></a></b>`
+        <a href="https://github.com/">link</a><span> and </span>
+        <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">another link</a></p>
+        <br /><a href="https://github.com/">Link</a><span> at the beginning, link at the </span>
+        <a href="https://github.com/"><span>end</span></a></b>`
       /* eslint-disable i18n-text/no-en */
-      const plaintextSentence =
-        'This is a https://github.com and another link\n\nLink at the beginning, link at the https://github.com/'
+      const plaintextSentence = 'This is a link and another link\n\nLink at the beginning, link at the end'
       /* eslint-enable i18n-text/no-en */
       const markdownSentence =
-        'This is a https://github.com/ and [another link](https://www.youtube.com/watch?v=dQw4w9WgXcQ)\n\n' +
-        '[Link](https://github.com/) at the beginning, link at the https://github.com/'
+        'This is a [link](https://github.com/) and [another link](https://www.youtube.com/watch?v=dQw4w9WgXcQ)\n\n' +
+        '[Link](https://github.com/) at the beginning, link at the [end](https://github.com/)'
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
+
+    it('finds the right link when identical labels are present', function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = `<meta charset='utf-8'><span>example<span> </span>
+      </span><a href="https://example.com/">example</a>`
+      const plaintextSentence = 'example example'
+      const markdownSentence = 'example [example](https://example.com/)'
 
       paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
       assert.equal(textarea.value, markdownSentence)


### PR DESCRIPTION
👋 Hello, this PR should fix https://github.com/github/paste-markdown/issues/45 by:

1. ([src](https://github.com/imjohnbo/paste-markdown/blob/b5eec8adb7d45fd2a63aab6629c87ea9acc6e93f/src/paste-markdown-html.ts#L33)) Getting all elements from HTML clipboard.
2. ([src](https://github.com/imjohnbo/paste-markdown/blob/b5eec8adb7d45fd2a63aab6629c87ea9acc6e93f/src/paste-markdown-html.ts#L67)) Finding the first occurrence of the matching text in the plaintext clipboard after a search index.
3. ([src](https://github.com/imjohnbo/paste-markdown/blob/b5eec8adb7d45fd2a63aab6629c87ea9acc6e93f/src/paste-markdown-html.ts#L70)) If this is a link, linkify it as before and increment the search index.
4. ([src](https://github.com/imjohnbo/paste-markdown/blob/b5eec8adb7d45fd2a63aab6629c87ea9acc6e93f/src/paste-markdown-html.ts#L78)) If it is not a link, simply increment the search index.

NOTE: I'm capping elements at 100,000, which seems reasonable, performant, and avoids accidental infinite loops.

Let me know what you think! See connected GitHub issue for more 👀.