### PR TITLE
Improve parsing of HTML anchor content

### DIFF
--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -30,7 +30,9 @@ function onPaste(event: ClipboardEvent) {
   // Generate DOM tree from HTML string
   const parser = new DOMParser()
   const doc = parser.parseFromString(textHTMLClean, 'text/html')
-  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT)
+  const walker = doc.createTreeWalker(doc.body, NodeFilter.SHOW_ELEMENT, node =>
+    node.parentNode && isLink(node.parentNode) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+  )
 
   const markdown = convertToMarkdown(plaintext, walker)
 

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -55,7 +55,9 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
   // Walk through the DOM tree
   while (currentNode && index < NODE_LIMIT) {
     index++
-    const text = isLink(currentNode) ? currentNode.textContent || '' : (currentNode.firstChild as Text)?.wholeText || ''
+    const text = isLink(currentNode)
+      ? (currentNode.textContent || '').replace(/[\t\n\r ]+/g, ' ')
+      : (currentNode.firstChild as Text)?.wholeText || ''
 
     // No need to transform whitespace
     if (isEmptyString(text)) {
@@ -68,7 +70,7 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
 
     if (markdownFoundIndex >= 0) {
       if (isLink(currentNode)) {
-        const markdownLink = linkify(currentNode)
+        const markdownLink = linkify(currentNode, text)
         // Transform 'example link plus more text' into 'example [link](example link) plus more text'
         // Method: 'example [link](example link) plus more text' = 'example ' + '[link](example link)' + ' plus more text'
         markdown =
@@ -99,8 +101,7 @@ function hasHTML(transfer: DataTransfer): boolean {
 }
 
 // Makes markdown link from a link element, avoiding special GitHub links
-function linkify(element: HTMLAnchorElement): string {
-  const label = element.textContent || ''
+function linkify(element: HTMLAnchorElement, label: string): string {
   const url = element.href || ''
   let markdown = ''
 

--- a/test/test.js
+++ b/test/test.js
@@ -160,6 +160,16 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, markdownSentence)
     })
 
+    it('deals with link labels that contains line breaks in html', function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = '<a href="https://example.com/">foo\nbar</a>'
+      const plaintextSentence = 'foo bar'
+      const markdownSentence = '[foo bar](https://example.com/)'
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
+
     it("doesn't render any markdown for html link without corresponding plaintext", function () {
       // eslint-disable-next-line github/unescaped-html-literal
       const link = `<meta charset='utf-8'><a href="https://github.com/monalisa/playground/issues/1">

--- a/test/test.js
+++ b/test/test.js
@@ -148,6 +148,18 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, markdownSentence)
     })
 
+    it('deals with links with nested html', function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = `<a href="https://example.com/"><span>foo</span></a>
+      <a href="https://example.com/">bar</a>
+      foo bar`
+      const plaintextSentence = 'foo bar foo bar'
+      const markdownSentence = '[foo](https://example.com/) [bar](https://example.com/) foo bar'
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
+
     it("doesn't render any markdown for html link without corresponding plaintext", function () {
       // eslint-disable-next-line github/unescaped-html-literal
       const link = `<meta charset='utf-8'><a href="https://github.com/monalisa/playground/issues/1">


### PR DESCRIPTION
This attempts to address https://github.com/github/paste-markdown/issues/53.

1. Fixes case 1 by skipping child elements of any link anchor
2. Fixes case 2 by normalizing whitespace (at least in the easy case) of anchor textContent

I'm not sure if this has any significant performance impact that should be evaluated. I tried to paste some large content and at least I didn't notice it being any slower than before. Calling a node filter on every element in the tree could be expensive, but maybe not too much?

This does not address the `<br>` case. I guess the only way to deal with it would be to traverse the children of the anchor and collect the text, but even that would probably not cover all the cases. And I suspect it might be too expensive if somehow it happens that the tree under the anchor element is very complex.

I also realized that using `innerText` instead of `textContent` doesn't work here (while normally it makes a difference), because when the element is not being rendered the DOM doesn't care about the semantics of `<br>`.

Please just take this as a suggestion. I mostly don't understand what I'm doing but wanted to give this a try anyway.