### PR TITLE
Support keyboard shortcut for formatted Vs Unformatted paste

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -1,61 +1,72 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>paste-markdown demo</title>
-  <style>
-    img, textarea { display: block; }
-    img, table, textarea { margin: 1em 0; }
-  </style>
-</head>
-<body>
-  <p>Test by selecting the elements and then either copy/paste or drag them into the textarea.</p>
-  <table border="1" cellpadding="5">
-    <thead>
-      <tr>
-        <th>name</th>
-        <th>origin</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>hubot</td>
-        <td>github</td>
-      </tr>
-      <tr>
-        <td>bender</td>
-        <td>futurama</td>
-      </tr>
-    </tbody>
-  </table>
+  <head>
+    <meta charset="utf-8" />
+    <title>paste-markdown demo</title>
+    <style>
+      img,
+      textarea {
+        display: block;
+      }
+      img,
+      table,
+      textarea {
+        margin: 1em 0;
+      }
+    </style>
+  </head>
+  <body>
+    <p>Test by selecting the elements and then either copy/paste or drag them into the textarea.</p>
+    <table border="1" cellpadding="5">
+      <thead>
+        <tr>
+          <th>name</th>
+          <th>origin</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>hubot</td>
+          <td>github</td>
+        </tr>
+        <tr>
+          <td>bender</td>
+          <td>futurama</td>
+        </tr>
+      </tbody>
+    </table>
 
-  <table border="1" cellpadding="5" data-paste-markdown-skip>
-    <thead>
-      <tr>
-        <th>name</th>
-        <th>origin</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>this table will not be</td>
-        <td>converted to markdown</td>
-      </tr>
-    </tbody>
-  </table>
+    <table border="1" cellpadding="5" data-paste-markdown-skip>
+      <thead>
+        <tr>
+          <th>name</th>
+          <th>origin</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>this table will not be</td>
+          <td>converted to markdown</td>
+        </tr>
+      </tbody>
+    </table>
 
-  <img src="https://github.com/hubot.png" width="100" alt="hubot">
+    <img src="https://github.com/hubot.png" width="100" alt="hubot" />
 
-  <p>Test by copying this page's URL and then selecting <i>here</i> in the textarea and pasting the URL.</p>
+    <p>Test by copying this page's URL and then selecting <i>here</i> in the textarea and pasting the URL.</p>
 
-  <p>Or copy and paste a <a href="https://github.com">link</a> and <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">another link</a> and maybe <a href="https://google.com">one more</a> into the textarea.</p>
+    <p>
+      Or copy and paste a <a href="https://github.com">link</a> and
+      <a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ">another link</a> and maybe
+      <a href="https://google.com">one more</a> into the textarea.
+    </p>
 
-  <textarea cols="50" rows="10">The examples can be found here.</textarea>
+    <textarea cols="50" rows="10">The examples can be found here.</textarea>
 
-  <script type="module">
-    // import {subscribe} from '../dist/index.esm.js'
-    import {subscribe} from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
-    subscribe(document.querySelector('textarea'))
-  </script>
-</body>
+    <script type="module">
+      import {subscribe} from '../dist/index.esm.js'
+      // import {subscribe} from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
+      subscribe(document.querySelector('textarea'))
+    </script>
+  </body>
 </html>

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,15 +1,24 @@
-const unformatted = new WeakMap<HTMLElement, boolean>()
+type UMap = WeakMap<HTMLElement, boolean>
+export class Unformatted {
+  map: UMap
 
-export function handleUnformatted(event: KeyboardEvent): void {
-  const {currentTarget: el} = event
-  if (event.code === 'KeyV' && (event.ctrlKey || event.metaKey) && event.shiftKey) {
-    unformatted.set(el as HTMLElement, true)
+  constructor() {
+    this.map = new WeakMap()
+    this.handleUnformatted = this.handleUnformatted.bind(this)
+    this.isUnformatted = this.isUnformatted.bind(this)
   }
-}
 
-export function isUnformatted(el: HTMLElement): boolean {
-  const isUnformattedState = unformatted.get(el) ?? false
-  unformatted.delete(el)
+  handleUnformatted(event: KeyboardEvent): void {
+    const {currentTarget: el} = event
+    if (event.code === 'KeyV' && (event.ctrlKey || event.metaKey) && event.shiftKey) {
+      this.map.set(el as HTMLElement, true)
+    }
+  }
 
-  return isUnformattedState
+  isUnformatted(el: HTMLElement): boolean {
+    const isUnformattedState = this.map.get(el) ?? false
+    this.map.delete(el)
+
+    return isUnformattedState
+  }
 }

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -1,0 +1,15 @@
+const unformatted = new WeakMap<HTMLElement, boolean>()
+
+export function handleUnformatted(event: KeyboardEvent): void {
+  const {currentTarget: el} = event
+  if (event.code === 'KeyV' && (event.ctrlKey || event.metaKey) && event.shiftKey) {
+    unformatted.set(el as HTMLElement, true)
+  }
+}
+
+export function isUnformatted(el: HTMLElement): boolean {
+  const isUnformattedState = unformatted.get(el) ?? false
+  unformatted.delete(el)
+
+  return isUnformattedState
+}

--- a/src/paste-keyboard-shortcut.ts
+++ b/src/paste-keyboard-shortcut.ts
@@ -4,18 +4,20 @@ export class PasteKeyBoardShortcut {
 
   constructor() {
     this.map = new WeakMap()
-    this.handleUnformatted = this.handleUnformatted.bind(this)
-    this.isUnformatted = this.isUnformatted.bind(this)
+    this.handleSkipFormatting = this.handleSkipFormatting.bind(this)
+    this.shouldSkipFormatting = this.shouldSkipFormatting.bind(this)
   }
 
-  handleUnformatted(event: KeyboardEvent): void {
+  handleSkipFormatting(event: KeyboardEvent): void {
     const {currentTarget: el} = event
-    if (event.code === 'KeyV' && (event.ctrlKey || event.metaKey) && event.shiftKey) {
+    const isSkipFormattingKeys = event.code === 'KeyV' && (event.ctrlKey || event.metaKey) && event.shiftKey
+
+    if (isSkipFormattingKeys || (isSkipFormattingKeys && event.altKey)) {
       this.map.set(el as HTMLElement, true)
     }
   }
 
-  isUnformatted(el: HTMLElement): boolean {
+  shouldSkipFormatting(el: HTMLElement): boolean {
     const isUnformattedState = this.map.get(el) ?? false
     this.map.delete(el)
 

--- a/src/paste-keyboard-shortcut.ts
+++ b/src/paste-keyboard-shortcut.ts
@@ -11,7 +11,7 @@ export class PasteKeyBoardShortcut {
   handleSkipFormatting(event: KeyboardEvent): void {
     const {currentTarget: el} = event
     const isSkipFormattingKeys = event.code === 'KeyV' && (event.ctrlKey || event.metaKey) && event.shiftKey
-
+    // Supports Cmd+Shift+V (Chrome) / Cmd+Shift+Opt+V (Safari, Firefox and Edge) to mimic paste and match style shortcut on MacOS.
     if (isSkipFormattingKeys || (isSkipFormattingKeys && event.altKey)) {
       this.map.set(el as HTMLElement, true)
     }

--- a/src/paste-keyboard-shortcut.ts
+++ b/src/paste-keyboard-shortcut.ts
@@ -1,5 +1,5 @@
 type UMap = WeakMap<HTMLElement, boolean>
-export class Unformatted {
+export class PasteKeyBoardShortcut {
   map: UMap
 
   constructor() {

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -1,20 +1,22 @@
-import {handleUnformatted, isUnformatted} from './handlers'
+import {Unformatted} from './handlers'
 import {insertText} from './text'
 
+const unformatted = new Unformatted()
+
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', handleUnformatted)
+  el.addEventListener('keydown', unformatted.handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', handleUnformatted)
+  el.removeEventListener('keydown', unformatted.handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const transfer = event.clipboardData
   const {currentTarget: el} = event
-  if (isUnformatted(el as HTMLElement)) return
+  if (unformatted.isUnformatted(el as HTMLElement)) return
   // if there is no clipboard data, or
   // if there is no html content in the clipboard, return
   if (!transfer || !hasHTML(transfer)) return

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -4,19 +4,19 @@ import {insertText} from './text'
 const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const transfer = event.clipboardData
   const {currentTarget: el} = event
-  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.shouldSkipFormatting(el as HTMLElement)) return
   // if there is no clipboard data, or
   // if there is no html content in the clipboard, return
   if (!transfer || !hasHTML(transfer)) return

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -1,22 +1,22 @@
-import {Unformatted} from './handlers'
+import {PasteKeyBoardShortcut} from './paste-keyboard-shortcut'
 import {insertText} from './text'
 
-const unformatted = new Unformatted()
+const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', unformatted.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', unformatted.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const transfer = event.clipboardData
   const {currentTarget: el} = event
-  if (unformatted.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
   // if there is no clipboard data, or
   // if there is no html content in the clipboard, return
   if (!transfer || !hasHTML(transfer)) return

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -1,15 +1,20 @@
+import {handleUnformatted, isUnformatted} from './handlers'
 import {insertText} from './text'
 
 export function install(el: HTMLElement): void {
+  el.addEventListener('keydown', handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
+  el.removeEventListener('keydown', handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const transfer = event.clipboardData
+  const {currentTarget: el} = event
+  if (isUnformatted(el as HTMLElement)) return
   // if there is no clipboard data, or
   // if there is no html content in the clipboard, return
   if (!transfer || !hasHTML(transfer)) return

--- a/src/paste-markdown-image-link.ts
+++ b/src/paste-markdown-image-link.ts
@@ -5,14 +5,14 @@ import {insertText} from './text'
 const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -43,7 +43,7 @@ function onDragover(event: DragEvent) {
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.shouldSkipFormatting(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasLink(transfer)) return

--- a/src/paste-markdown-image-link.ts
+++ b/src/paste-markdown-image-link.ts
@@ -1,14 +1,16 @@
 /* @flow strict */
-
+import {handleUnformatted, isUnformatted} from './handlers'
 import {insertText} from './text'
 
 export function install(el: HTMLElement): void {
+  el.addEventListener('keydown', handleUnformatted)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
+  el.removeEventListener('keydown', handleUnformatted)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -38,6 +40,9 @@ function onDragover(event: DragEvent) {
 }
 
 function onPaste(event: ClipboardEvent) {
+  const {currentTarget: el} = event
+  if (isUnformatted(el as HTMLElement)) return
+
   const transfer = event.clipboardData
   if (!transfer || !hasLink(transfer)) return
 

--- a/src/paste-markdown-image-link.ts
+++ b/src/paste-markdown-image-link.ts
@@ -1,18 +1,18 @@
 /* @flow strict */
-import {Unformatted} from './handlers'
+import {PasteKeyBoardShortcut} from './paste-keyboard-shortcut'
 import {insertText} from './text'
 
-const unformatted = new Unformatted()
+const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', unformatted.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', unformatted.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -43,7 +43,7 @@ function onDragover(event: DragEvent) {
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (unformatted.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasLink(transfer)) return

--- a/src/paste-markdown-image-link.ts
+++ b/src/paste-markdown-image-link.ts
@@ -1,16 +1,18 @@
 /* @flow strict */
-import {handleUnformatted, isUnformatted} from './handlers'
+import {Unformatted} from './handlers'
 import {insertText} from './text'
 
+const unformatted = new Unformatted()
+
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', handleUnformatted)
+  el.addEventListener('keydown', unformatted.handleUnformatted)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', handleUnformatted)
+  el.removeEventListener('keydown', unformatted.handleUnformatted)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -41,7 +43,7 @@ function onDragover(event: DragEvent) {
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (isUnformatted(el as HTMLElement)) return
+  if (unformatted.isUnformatted(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasLink(transfer)) return

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -1,14 +1,20 @@
+import {handleUnformatted, isUnformatted} from './handlers'
 import {insertText} from './text'
 
 export function install(el: HTMLElement): void {
+  el.addEventListener('keydown', handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
+  el.removeEventListener('keydown', handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
+  const {currentTarget: el} = event
+  if (isUnformatted(el as HTMLElement)) return
+
   const transfer = event.clipboardData
   if (!transfer || !hasPlainText(transfer)) return
 

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -1,21 +1,21 @@
-import {Unformatted} from './handlers'
+import {PasteKeyBoardShortcut} from './paste-keyboard-shortcut'
 import {insertText} from './text'
 
-const unformatted = new Unformatted()
+const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', unformatted.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', unformatted.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (unformatted.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasPlainText(transfer)) return

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -4,18 +4,18 @@ import {insertText} from './text'
 const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.shouldSkipFormatting(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasPlainText(transfer)) return

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -1,19 +1,21 @@
-import {handleUnformatted, isUnformatted} from './handlers'
+import {Unformatted} from './handlers'
 import {insertText} from './text'
 
+const unformatted = new Unformatted()
+
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', handleUnformatted)
+  el.addEventListener('keydown', unformatted.handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', handleUnformatted)
+  el.removeEventListener('keydown', unformatted.handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (isUnformatted(el as HTMLElement)) return
+  if (unformatted.isUnformatted(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasPlainText(transfer)) return

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -1,17 +1,17 @@
-import {Unformatted} from './handlers'
+import {PasteKeyBoardShortcut} from './paste-keyboard-shortcut'
 import {insertText} from './text'
 
-const unformatted = new Unformatted()
+const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', unformatted.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', unformatted.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -41,7 +41,7 @@ function onDragover(event: DragEvent) {
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (unformatted.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
 
   if (!event.clipboardData) return
 

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -1,15 +1,17 @@
-import {handleUnformatted, isUnformatted} from './handlers'
+import {Unformatted} from './handlers'
 import {insertText} from './text'
 
+const unformatted = new Unformatted()
+
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', handleUnformatted)
+  el.addEventListener('keydown', unformatted.handleUnformatted)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', handleUnformatted)
+  el.removeEventListener('keydown', unformatted.handleUnformatted)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -39,7 +41,7 @@ function onDragover(event: DragEvent) {
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (isUnformatted(el as HTMLElement)) return
+  if (unformatted.isUnformatted(el as HTMLElement)) return
 
   if (!event.clipboardData) return
 

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -1,12 +1,15 @@
+import {handleUnformatted, isUnformatted} from './handlers'
 import {insertText} from './text'
 
 export function install(el: HTMLElement): void {
+  el.addEventListener('keydown', handleUnformatted)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
+  el.removeEventListener('keydown', handleUnformatted)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -35,6 +38,9 @@ function onDragover(event: DragEvent) {
 }
 
 function onPaste(event: ClipboardEvent) {
+  const {currentTarget: el} = event
+  if (isUnformatted(el as HTMLElement)) return
+
   if (!event.clipboardData) return
 
   const textToPaste = generateText(event.clipboardData)

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -4,14 +4,14 @@ import {insertText} from './text'
 const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.addEventListener('dragover', onDragover)
   el.addEventListener('drop', onDrop)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.removeEventListener('dragover', onDragover)
   el.removeEventListener('drop', onDrop)
   el.removeEventListener('paste', onPaste)
@@ -41,7 +41,7 @@ function onDragover(event: DragEvent) {
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.shouldSkipFormatting(el as HTMLElement)) return
 
   if (!event.clipboardData) return
 

--- a/src/paste-markdown-text.ts
+++ b/src/paste-markdown-text.ts
@@ -1,14 +1,20 @@
+import {handleUnformatted, isUnformatted} from './handlers'
 import {insertText} from './text'
 
 export function install(el: HTMLElement): void {
+  el.addEventListener('keydown', handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
+  el.removeEventListener('keydown', handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
+  const {currentTarget: el} = event
+  if (isUnformatted(el as HTMLElement)) return
+
   const transfer = event.clipboardData
   if (!transfer || !hasMarkdown(transfer)) return
 

--- a/src/paste-markdown-text.ts
+++ b/src/paste-markdown-text.ts
@@ -4,18 +4,18 @@ import {insertText} from './text'
 const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleSkipFormatting)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.shouldSkipFormatting(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasMarkdown(transfer)) return

--- a/src/paste-markdown-text.ts
+++ b/src/paste-markdown-text.ts
@@ -1,21 +1,21 @@
-import {Unformatted} from './handlers'
+import {PasteKeyBoardShortcut} from './paste-keyboard-shortcut'
 import {insertText} from './text'
 
-const unformatted = new Unformatted()
+const pasteKeyBoardShortcut = new PasteKeyBoardShortcut()
 
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', unformatted.handleUnformatted)
+  el.addEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', unformatted.handleUnformatted)
+  el.removeEventListener('keydown', pasteKeyBoardShortcut.handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (unformatted.isUnformatted(el as HTMLElement)) return
+  if (pasteKeyBoardShortcut.isUnformatted(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasMarkdown(transfer)) return

--- a/src/paste-markdown-text.ts
+++ b/src/paste-markdown-text.ts
@@ -1,19 +1,21 @@
-import {handleUnformatted, isUnformatted} from './handlers'
+import {Unformatted} from './handlers'
 import {insertText} from './text'
 
+const unformatted = new Unformatted()
+
 export function install(el: HTMLElement): void {
-  el.addEventListener('keydown', handleUnformatted)
+  el.addEventListener('keydown', unformatted.handleUnformatted)
   el.addEventListener('paste', onPaste)
 }
 
 export function uninstall(el: HTMLElement): void {
-  el.removeEventListener('keydown', handleUnformatted)
+  el.removeEventListener('keydown', unformatted.handleUnformatted)
   el.removeEventListener('paste', onPaste)
 }
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (isUnformatted(el as HTMLElement)) return
+  if (unformatted.isUnformatted(el as HTMLElement)) return
 
   const transfer = event.clipboardData
   if (!transfer || !hasMarkdown(transfer)) return


### PR DESCRIPTION
Ref: https://github.com/github/special-projects/issues/966

**Context:**
Add support for keyboard shortcuts where when : `cmd/ctrl+ shift + v` pastes _unformatted_ content like for paste links `http://... ` and  `cmd/ctrl + v`  _formatted_  auto linked link on selected text like ` [...](http://...)`


https://user-images.githubusercontent.com/18541122/167987341-0ac2ae38-5d4e-4874-aa32-235b4870914c.mov

### Approach 2
This PR adds support for paste on using keyboard shortcuts - this approaches the fix by creating a class with required `keydown` handler/helper methods to toggle state which would decide when to paste formatted ( markdown ) content Vs not for a consistent paste.

🍐 @theinterned 
