### PR TITLE
do not format as markdown when pasting after at mention

### DIFF
--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -97,13 +97,12 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
 
 function isWithinUserMention(textarea: HTMLTextAreaElement): boolean {
   const selectionStart = textarea.selectionStart || 0
-
-  if (selectionStart > 0) {
-    const previousChar = textarea.value.substring(selectionStart - 1, selectionStart)
-    return previousChar === '@'
-  } else {
+  if (selectionStart === 0) {
     return false
   }
+
+  const previousChar = textarea.value.substring(selectionStart - 1, selectionStart)
+  return previousChar === '@'
 }
 
 function isEmptyString(text: string): boolean {

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -20,6 +20,10 @@ function onPaste(event: ClipboardEvent) {
   const field = event.currentTarget
   if (!(field instanceof HTMLTextAreaElement)) return
 
+  if (isWithinUserMention(field)) {
+    return
+  }
+
   // Get the plaintext and html version of clipboard contents
   let plaintext = transfer.getData('text/plain')
   const textHTML = transfer.getData('text/html')
@@ -89,6 +93,17 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
 
   // Unless we hit the node limit, we should have processed all nodes
   return index === NODE_LIMIT ? plaintext : markdown
+}
+
+function isWithinUserMention(textarea: HTMLTextAreaElement): boolean {
+  const selectionStart = textarea.selectionStart || 0
+
+  if (selectionStart > 0) {
+    const previousChar = textarea.value.substring(selectionStart - 1, selectionStart)
+    return previousChar === '@'
+  } else {
+    return false
+  }
 }
 
 function isEmptyString(text: string): boolean {

--- a/test/test.js
+++ b/test/test.js
@@ -53,6 +53,19 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, 'The examples can be found here: https://docs.github.com')
     })
 
+    it("doesn't paste markdown URL when pasting after user at mentions", function () {
+      textarea.value = '@'
+      textarea.setSelectionRange(1, 1)
+      const html = `
+      <a href="http://github.localhost/monalisa">monalisa</a>
+      `
+      paste(textarea, {'text/plain': 'monalisa', 'text/html': html})
+
+      // No change in textarea value here means no custom paste event handler was fired.
+      // So the browser default paste handler will be used.
+      assert.equal(textarea.value, '@')
+    })
+
     it('turns html tables into markdown', function () {
       const data = {
         'text/html': tableHtml


### PR DESCRIPTION
This PR adds logic to skip formatting `html` pastebin data if the user pastes directly after a `@` sign. 
In the future this can be extended to support a few `ignore_characters` or strings as input when the library is loaded.