### PR TITLE
Only paste links when pasted text is only a URL

### DIFF
--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -55,6 +55,7 @@ function linkify(selectedText: string, text: string): string {
   return `[${selectedText}](${text})`
 }
 
+const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\/?\s*?$/i
 function isURL(url: string): boolean {
-  return /^https?:\/\//i.test(url)
+  return URL_REGEX.test(url)
 }

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,14 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
     })
 
+    it('creates a markdown link when the pasted url includes a trailing slash', function () {
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      paste(textarea, {'text/plain': 'https://www.github.com/'})
+      assert.equal(textarea.value, 'The examples can be found [here](https://www.github.com/).')
+    })
+
     it("doesn't paste a markdown URL when pasting over a selected URL", function () {
       // eslint-disable-next-line i18n-text/no-en
       textarea.value = 'The examples can be found here: https://docs.github.com'
@@ -64,6 +72,15 @@ describe('paste-markdown', function () {
       // No change in textarea value here means no custom paste event handler was fired.
       // So the browser default paste handler will be used.
       assert.equal(textarea.value, '@')
+    })
+
+    it("doesn't paste markdown URL when additional text is being copied", function () {
+      textarea.value = 'github'
+      textarea.setSelectionRange(0, 6)
+      paste(textarea, {'text/plain': 'https://github.com plus some other content'})
+      // Synthetic paste events don't manipulate the DOM. The same textarea value
+      // means that the event handler didn't fire and normal paste happened.
+      assert.equal(textarea.value, 'github')
     })
 
     it('turns html tables into markdown', function () {


### PR DESCRIPTION
When inserted markdown links, we were testing the pasted text to see if it contained a URL (via a RegExp that was looking for `https?`) and, if it matched, attempting to use that as the URL for a markdown link with the target text as the text. However, this causes an undesired behavior if there's additional text that's being pasted. See the example videos below:

https://user-images.githubusercontent.com/6826778/184047954-b49e32d1-d4ce-446e-9e83-45958ed07e16.mov

This PR tightens up the RegEx to ensure we're pasting an exact URL. I tweaked the RegEx logic from this SO post https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url