### PR TITLE
Update to support longer URLs

### DIFF
--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -55,7 +55,7 @@ function linkify(selectedText: string, text: string): string {
   return `[${selectedText}](${text})`
 }
 
-const URL_REGEX = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\/?\s*?$/i
+const URL_REGEX = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$/i
 function isURL(url: string): boolean {
   return URL_REGEX.test(url)
 }

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -33,7 +33,7 @@ function onPaste(event: ClipboardEvent) {
   event.stopPropagation()
   event.preventDefault()
 
-  insertText(field, linkify(selectedText, text))
+  insertText(field, linkify(selectedText, text.trim()))
 }
 
 function hasPlainText(transfer: DataTransfer): boolean {
@@ -59,7 +59,7 @@ function isURL(url: string): boolean {
   try {
     //eslint-disable-next-line no-restricted-syntax
     const parsedURL = new URL(url)
-    return removeTrailingSlash(parsedURL.href) === removeTrailingSlash(url)
+    return removeTrailingSlash(parsedURL.href).trim() === removeTrailingSlash(url).trim()
   } catch {
     return false
   }

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -55,7 +55,15 @@ function linkify(selectedText: string, text: string): string {
   return `[${selectedText}](${text})`
 }
 
-const URL_REGEX = /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*)$/i
 function isURL(url: string): boolean {
-  return URL_REGEX.test(url)
+  try {
+    //eslint-disable-next-line no-restricted-syntax
+    const parsedURL = new URL(url)
+    return removeTrailingSlash(parsedURL.href) === removeTrailingSlash(url)
+  } catch {
+    return false
+  }
+}
+function removeTrailingSlash(url: string) {
+  return url.endsWith('/') ? url.slice(0, url.length - 1) : url
 }

--- a/test/test.js
+++ b/test/test.js
@@ -55,8 +55,33 @@ describe('paste-markdown', function () {
       // eslint-disable-next-line i18n-text/no-en
       textarea.value = 'The examples can be found here.'
       textarea.setSelectionRange(26, 30)
-      paste(textarea, {'text/plain': 'https://www.github.com/path/to/something'})
-      assert.equal(textarea.value, 'The examples can be found [here](https://www.github.com/path/to/something).')
+      paste(textarea, {'text/plain': 'https://www.github.com/path_to/something-different/too'})
+      assert.equal(
+        textarea.value,
+        'The examples can be found [here](https://www.github.com/path_to/something-different/too).'
+      )
+    })
+
+    it('creates a markdown link with query string', function () {
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      paste(textarea, {'text/plain': 'https://www.github.com/path/to/something?query=true'})
+      assert.equal(
+        textarea.value,
+        'The examples can be found [here](https://www.github.com/path/to/something?query=true).'
+      )
+    })
+
+    it('creates a markdown link with hash params', function () {
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      paste(textarea, {'text/plain': 'https://www.github.com/path/to/something#section'})
+      assert.equal(
+        textarea.value,
+        'The examples can be found [here](https://www.github.com/path/to/something#section).'
+      )
     })
 
     it('creates a link for http urls', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,23 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, 'The examples can be found [here](https://www.github.com/).')
     })
 
+    it('creates a markdown link for longer urls', function () {
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      paste(textarea, {'text/plain': 'https://www.github.com/path/to/something'})
+      assert.equal(textarea.value, 'The examples can be found [here](https://www.github.com/path/to/something).')
+    })
+
+    it('creates a link for http urls', function () {
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'Look over here please'
+      textarea.setSelectionRange(10, 14)
+      const url = 'http://someotherdomain.org/another/thing'
+      paste(textarea, {'text/plain': url})
+      assert.equal(textarea.value, `Look over [here](${url}) please`)
+    })
+
     it("doesn't paste a markdown URL when pasting over a selected URL", function () {
       // eslint-disable-next-line i18n-text/no-en
       textarea.value = 'The examples can be found here: https://docs.github.com'

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,15 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, `Look over [here](${url}) please`)
     })
 
+    it('creates a link when copied content includes spaces and a newline', () => {
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'Look over here please'
+      textarea.setSelectionRange(10, 14)
+      const url = 'http://someotherdomain.org/another/thing            \n'
+      paste(textarea, {'text/plain': url})
+      assert.equal(textarea.value, `Look over [here](${url.trim()}) please`)
+    })
+
     it("doesn't paste a markdown URL when pasting over a selected URL", function () {
       // eslint-disable-next-line i18n-text/no-en
       textarea.value = 'The examples can be found here: https://docs.github.com'


### PR DESCRIPTION
The bugfix I introduced in https://github.com/github/paste-markdown/pull/65 caused a regression because we were no longer accounting for paths after the initial slash at the end of the domain. This PR updates the URL validation to rely on creating a new `URL` instead. This will throw an exception if the URL is not valid. 

In addition, we check to make sure that the parsed href matches the original URL passed in. This accounts for cases like `http://example.com and some other stuff`, which would count as a valid URL (parsed to `http://example.com%20and%20some%20other%20stuff`), but not be content that we actually want to treat as a URL. 

Even with this extra check, felt a lot nicer than needing to deal with a RegExp 😅 