### PR TITLE
Add architecture for granual pasteAsPlainText support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ Some `<table>`s are not meant to be pasted as markdown; for example, a file cont
 </table>
 ```
 
+### Granular control for pasting as plain text
+
+If you're wanting more granular support of pasting certain items as plain text by default, you can pass in the controls config at the `subscribe` level.
+
+Our config support looks as follows:
+
+```js
+import {subscribe} from '@github/paste-markdown'
+
+// Subscribe the behavior to the textarea with pasting URL links as plain text by default.
+subscribe(document.querySelector('textarea[data-paste-markdown]'), {defaultPlainTextPaste: {urlLinks: true}})
+```
+
+In this scenario above, pasting a URL over selected text will paste as plain text by default, but pasting a table will still paste as markdown by default.
+
+Only the `urlLinks` param is currently supported.
+
+If there is no config passed in, or attributes missing, this will always default to `false`, being the existing behavior.
+
 ## Development
 
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,13 +30,7 @@ function subscribe(el: HTMLElement, optionConfig?: OptionConfig): Subscription {
 }
 
 function markElementWithConfigIfNeeded(el: HTMLElement, optionConfig?: OptionConfig) {
-  // eslint-disable-next-line no-console
-  console.log(optionConfig)
-
   if (optionConfig?.pasteAsPlainText) {
-    // eslint-disable-next-line no-console
-    console.log(optionConfig?.pasteAsPlainText, 'HERE')
-
     el.setAttribute(PASTE_AS_PLAIN_TEXT_ATTRIBUTE, 'true')
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ interface Subscription {
 }
 
 function subscribe(el: HTMLElement, optionConfig?: OptionConfig): Subscription {
-  installSkipFormatting(el, [installTable, installImageLink, installText, installHTML], [installLink], optionConfig)
+  installSkipFormatting(el, [installTable, installImageLink, installLink, installText, installHTML], optionConfig)
   return {
     unsubscribe: () => {
       uninstallSkipFormatting(el)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import {OptionConfig, PASTE_AS_PLAIN_TEXT_ATTRIBUTE} from './option-config'
 import {install as installHTML, uninstall as uninstallHTML} from './paste-markdown-html'
 import {install as installImageLink, uninstall as uninstallImageLink} from './paste-markdown-image-link'
 import {install as installLink, uninstall as uninstallLink} from './paste-markdown-link'
@@ -12,9 +13,10 @@ interface Subscription {
   unsubscribe: () => void
 }
 
-function subscribe(el: HTMLElement): Subscription {
-  installSkipFormatting(el, installTable, installImageLink, installLink, installText, installHTML)
+function subscribe(el: HTMLElement, optionConfig?: OptionConfig): Subscription {
+  markElementWithConfigIfNeeded(el, optionConfig)
 
+  installSkipFormatting(el, installTable, installImageLink, installLink, installText, installHTML)
   return {
     unsubscribe: () => {
       uninstallSkipFormatting(el)
@@ -24,6 +26,18 @@ function subscribe(el: HTMLElement): Subscription {
       uninstallLink(el)
       uninstallText(el)
     }
+  }
+}
+
+function markElementWithConfigIfNeeded(el: HTMLElement, optionConfig?: OptionConfig) {
+  // eslint-disable-next-line no-console
+  console.log(optionConfig)
+
+  if (optionConfig?.pasteAsPlainText) {
+    // eslint-disable-next-line no-console
+    console.log(optionConfig?.pasteAsPlainText, 'HERE')
+
+    el.setAttribute(PASTE_AS_PLAIN_TEXT_ATTRIBUTE, 'true')
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import {OptionConfig, PASTE_AS_PLAIN_TEXT_ATTRIBUTE} from './option-config'
 import {install as installHTML, uninstall as uninstallHTML} from './paste-markdown-html'
 import {install as installImageLink, uninstall as uninstallImageLink} from './paste-markdown-image-link'
 import {install as installLink, uninstall as uninstallLink} from './paste-markdown-link'
@@ -8,15 +7,14 @@ import {
 } from './paste-keyboard-shortcut-helper'
 import {install as installTable, uninstall as uninstallTable} from './paste-markdown-table'
 import {install as installText, uninstall as uninstallText} from './paste-markdown-text'
+import {OptionConfig} from './option-config'
 
 interface Subscription {
   unsubscribe: () => void
 }
 
 function subscribe(el: HTMLElement, optionConfig?: OptionConfig): Subscription {
-  markElementWithConfigIfNeeded(el, optionConfig)
-
-  installSkipFormatting(el, installTable, installImageLink, installLink, installText, installHTML)
+  installSkipFormatting(el, [installTable, installImageLink, installText, installHTML], [installLink], optionConfig)
   return {
     unsubscribe: () => {
       uninstallSkipFormatting(el)
@@ -26,12 +24,6 @@ function subscribe(el: HTMLElement, optionConfig?: OptionConfig): Subscription {
       uninstallLink(el)
       uninstallText(el)
     }
-  }
-}
-
-function markElementWithConfigIfNeeded(el: HTMLElement, optionConfig?: OptionConfig) {
-  if (optionConfig?.pasteAsPlainText) {
-    el.setAttribute(PASTE_AS_PLAIN_TEXT_ATTRIBUTE, 'true')
   }
 }
 

--- a/src/option-config.ts
+++ b/src/option-config.ts
@@ -1,7 +1,3 @@
-const PASTE_AS_PLAIN_TEXT_ATTRIBUTE = 'data-paste-as-plain-text'
-
-interface OptionConfig {
+export interface OptionConfig {
   pasteAsPlainText?: boolean
 }
-
-export {PASTE_AS_PLAIN_TEXT_ATTRIBUTE, OptionConfig}

--- a/src/option-config.ts
+++ b/src/option-config.ts
@@ -1,3 +1,3 @@
 export interface OptionConfig {
-  pasteAsPlainText?: boolean
+  pasteLinkAsPlainTextOverSelectedText?: boolean
 }

--- a/src/option-config.ts
+++ b/src/option-config.ts
@@ -8,6 +8,6 @@ interface PlainTextParams {
   // Not currently implemented behavior
   /*imageLinks?: boolean
   html?: boolean
-  table?: boolean
+  tables?: boolean
   text?: boolean*/
 }

--- a/src/option-config.ts
+++ b/src/option-config.ts
@@ -1,0 +1,7 @@
+const PASTE_AS_PLAIN_TEXT_ATTRIBUTE = 'data-paste-as-plain-text'
+
+interface OptionConfig {
+  pasteAsPlainText?: boolean
+}
+
+export {PASTE_AS_PLAIN_TEXT_ATTRIBUTE, OptionConfig}

--- a/src/option-config.ts
+++ b/src/option-config.ts
@@ -1,3 +1,13 @@
 export interface OptionConfig {
-  pasteLinkAsPlainTextOverSelectedText?: boolean
+  defaultPlainTextPaste?: PlainTextParams
+}
+
+interface PlainTextParams {
+  urlLinks?: boolean
+
+  // Not currently implemented behavior
+  /*imageLinks?: boolean
+  html?: boolean
+  table?: boolean
+  text?: boolean*/
 }

--- a/src/paste-keyboard-shortcut-helper.ts
+++ b/src/paste-keyboard-shortcut-helper.ts
@@ -1,3 +1,5 @@
+import {OptionConfig} from './option-config'
+
 const skipFormattingMap = new WeakMap<HTMLElement, boolean>()
 
 function setSkipFormattingFlag(event: KeyboardEvent): void {
@@ -21,11 +23,20 @@ export function shouldSkipFormatting(el: HTMLElement): boolean {
   return shouldSkipFormattingState
 }
 
-export function installAround(el: HTMLElement, ...installCallbacks: Array<(el: HTMLElement) => void>): void {
+export function installAround(
+  el: HTMLElement,
+  installCallbacks: Array<(el: HTMLElement) => void>,
+  installCallbacksWithOptions: Array<(el: HTMLElement, optionConfig?: OptionConfig) => void>,
+  optionConfig?: OptionConfig
+): void {
   el.addEventListener('keydown', setSkipFormattingFlag)
 
   for (const installCallback of installCallbacks) {
     installCallback(el)
+  }
+
+  for (const installCallback of installCallbacksWithOptions) {
+    installCallback(el, optionConfig)
   }
 
   el.addEventListener('paste', unsetSkipFormattedFlag)

--- a/src/paste-keyboard-shortcut-helper.ts
+++ b/src/paste-keyboard-shortcut-helper.ts
@@ -25,17 +25,12 @@ export function shouldSkipFormatting(el: HTMLElement): boolean {
 
 export function installAround(
   el: HTMLElement,
-  installCallbacks: Array<(el: HTMLElement) => void>,
-  installCallbacksWithOptions: Array<(el: HTMLElement, optionConfig?: OptionConfig) => void>,
+  installCallbacks: Array<(el: HTMLElement, optionConfig?: OptionConfig) => void>,
   optionConfig?: OptionConfig
 ): void {
   el.addEventListener('keydown', setSkipFormattingFlag)
 
   for (const installCallback of installCallbacks) {
-    installCallback(el)
-  }
-
-  for (const installCallback of installCallbacksWithOptions) {
     installCallback(el, optionConfig)
   }
 

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -1,3 +1,4 @@
+import {PASTE_AS_PLAIN_TEXT_ATTRIBUTE} from './option-config'
 import {insertText} from './text'
 import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
 
@@ -11,7 +12,13 @@ export function uninstall(el: HTMLElement): void {
 
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
-  if (shouldSkipFormatting(el as HTMLElement)) return
+  const element = el as HTMLElement
+  const shouldPastePlainText = element.hasAttribute(PASTE_AS_PLAIN_TEXT_ATTRIBUTE)
+  const shouldSkipDefaultBehavior = shouldSkipFormatting(element)
+
+  if ((!shouldPastePlainText && shouldSkipDefaultBehavior) || (shouldPastePlainText && !shouldSkipDefaultBehavior)) {
+    return
+  }
 
   const transfer = event.clipboardData
   if (!transfer || !hasPlainText(transfer)) return
@@ -26,6 +33,7 @@ function onPaste(event: ClipboardEvent) {
 
   const selectedText = field.value.substring(field.selectionStart, field.selectionEnd)
   if (!selectedText.length) return
+
   // Prevent linkification when replacing an URL
   // Trim whitespace in case whitespace is selected by mistake or by intention
   if (isURL(selectedText.trim())) return

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -1,8 +1,11 @@
-import {PASTE_AS_PLAIN_TEXT_ATTRIBUTE} from './option-config'
+import {OptionConfig} from './option-config'
 import {insertText} from './text'
 import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
 
-export function install(el: HTMLElement): void {
+const pasteAsPlainTextMap = new WeakMap<HTMLElement, boolean>()
+
+export function install(el: HTMLElement, optionConfig?: OptionConfig): void {
+  pasteAsPlainTextMap.set(el, optionConfig?.pasteAsPlainText === true)
   el.addEventListener('paste', onPaste)
 }
 
@@ -13,7 +16,7 @@ export function uninstall(el: HTMLElement): void {
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
   const element = el as HTMLElement
-  const shouldPastePlainText = element.hasAttribute(PASTE_AS_PLAIN_TEXT_ATTRIBUTE)
+  const shouldPastePlainText = pasteAsPlainTextMap.get(element) ?? false
   const shouldSkipDefaultBehavior = shouldSkipFormatting(element)
 
   if ((!shouldPastePlainText && shouldSkipDefaultBehavior) || (shouldPastePlainText && !shouldSkipDefaultBehavior)) {

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -5,7 +5,7 @@ import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
 const pasteLinkAsPlainTextOverSelectedTextMap = new WeakMap<HTMLElement, boolean>()
 
 export function install(el: HTMLElement, optionConfig?: OptionConfig): void {
-  pasteLinkAsPlainTextOverSelectedTextMap.set(el, optionConfig?.pasteLinkAsPlainTextOverSelectedText === true)
+  pasteLinkAsPlainTextOverSelectedTextMap.set(el, optionConfig?.defaultPlainTextPaste?.urlLinks === true)
   el.addEventListener('paste', onPaste)
 }
 

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -2,10 +2,10 @@ import {OptionConfig} from './option-config'
 import {insertText} from './text'
 import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
 
-const pasteAsPlainTextMap = new WeakMap<HTMLElement, boolean>()
+const pasteLinkAsPlainTextOverSelectedTextMap = new WeakMap<HTMLElement, boolean>()
 
 export function install(el: HTMLElement, optionConfig?: OptionConfig): void {
-  pasteAsPlainTextMap.set(el, optionConfig?.pasteAsPlainText === true)
+  pasteLinkAsPlainTextOverSelectedTextMap.set(el, optionConfig?.pasteLinkAsPlainTextOverSelectedText === true)
   el.addEventListener('paste', onPaste)
 }
 
@@ -16,10 +16,13 @@ export function uninstall(el: HTMLElement): void {
 function onPaste(event: ClipboardEvent) {
   const {currentTarget: el} = event
   const element = el as HTMLElement
-  const shouldPastePlainText = pasteAsPlainTextMap.get(element) ?? false
+  const shouldPasteAsPlainText = pasteLinkAsPlainTextOverSelectedTextMap.get(element) ?? false
   const shouldSkipDefaultBehavior = shouldSkipFormatting(element)
 
-  if ((!shouldPastePlainText && shouldSkipDefaultBehavior) || (shouldPastePlainText && !shouldSkipDefaultBehavior)) {
+  if (
+    (!shouldPasteAsPlainText && shouldSkipDefaultBehavior) ||
+    (shouldPasteAsPlainText && !shouldSkipDefaultBehavior)
+  ) {
     return
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,38 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
     })
 
+    it('turns pasted urls on selected text into markdown links if pasteAsPlainText is false', function () {
+      subscription = subscribeWithOptionConfig(subscription, textarea, false)
+
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      paste(textarea, {'text/plain': 'https://github.com'})
+      assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
+    })
+
+    it('turns pasted urls on selected text into markdown links if pasteAsPlainText is true and skip format flag is true', function () {
+      subscription = subscribeWithOptionConfig(subscription, textarea, true)
+
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      dispatchSkipFormattingKeyEvent(textarea)
+      paste(textarea, {'text/plain': 'https://github.com'})
+      assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
+    })
+
+    it('pastes as plain text on selected text if pasteAsPlainText is true', function () {
+      subscription = subscribeWithOptionConfig(subscription, textarea, true)
+
+      // eslint-disable-next-line i18n-text/no-en
+      textarea.value = 'The examples can be found here.'
+      textarea.setSelectionRange(26, 30)
+      paste(textarea, {'text/plain': 'https://github.com'})
+      // The text area will be unchanged at this stage as the paste won't be handled by our listener
+      assert.equal(textarea.value, 'The examples can be found here.')
+    })
+
     it('creates a markdown link when the pasted url includes a trailing slash', function () {
       // eslint-disable-next-line i18n-text/no-en
       textarea.value = 'The examples can be found here.'
@@ -351,6 +383,12 @@ function dispatchSkipFormattingKeyEvent(textarea) {
       metaKey: true
     })
   )
+}
+
+function subscribeWithOptionConfig(subscription, textarea, pasteAsPlainText) {
+  // Clear the before test subscription with no config and re-subscribe with config
+  subscription.unsubscribe()
+  return subscribe(textarea, {pasteAsPlainText})
 }
 
 function paste(textarea, data) {

--- a/test/test.js
+++ b/test/test.js
@@ -385,10 +385,10 @@ function dispatchSkipFormattingKeyEvent(textarea) {
   )
 }
 
-function subscribeWithOptionConfig(subscription, textarea, pasteLinkAsPlainTextOverSelectedText) {
+function subscribeWithOptionConfig(subscription, textarea, urlLinks) {
   // Clear the before test subscription with no config and re-subscribe with config
   subscription.unsubscribe()
-  return subscribe(textarea, {pasteLinkAsPlainTextOverSelectedText})
+  return subscribe(textarea, {defaultPlainTextPaste: {urlLinks}})
 }
 
 function paste(textarea, data) {

--- a/test/test.js
+++ b/test/test.js
@@ -43,7 +43,7 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
     })
 
-    it('turns pasted urls on selected text into markdown links if pasteAsPlainText is false', function () {
+    it('turns pasted urls on selected text into markdown links if pasteLinkAsPlainTextOverSelectedText is false', function () {
       subscription = subscribeWithOptionConfig(subscription, textarea, false)
 
       // eslint-disable-next-line i18n-text/no-en
@@ -53,7 +53,7 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
     })
 
-    it('turns pasted urls on selected text into markdown links if pasteAsPlainText is true and skip format flag is true', function () {
+    it('turns pasted urls on selected text into markdown links if pasteLinkAsPlainTextOverSelectedText is true and skip format flag is true', function () {
       subscription = subscribeWithOptionConfig(subscription, textarea, true)
 
       // eslint-disable-next-line i18n-text/no-en
@@ -64,7 +64,7 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, 'The examples can be found [here](https://github.com).')
     })
 
-    it('pastes as plain text on selected text if pasteAsPlainText is true', function () {
+    it('pastes as plain text on selected text if pasteLinkAsPlainTextOverSelectedText is true', function () {
       subscription = subscribeWithOptionConfig(subscription, textarea, true)
 
       // eslint-disable-next-line i18n-text/no-en
@@ -385,10 +385,10 @@ function dispatchSkipFormattingKeyEvent(textarea) {
   )
 }
 
-function subscribeWithOptionConfig(subscription, textarea, pasteAsPlainText) {
+function subscribeWithOptionConfig(subscription, textarea, pasteLinkAsPlainTextOverSelectedText) {
   // Clear the before test subscription with no config and re-subscribe with config
   subscription.unsubscribe()
-  return subscribe(textarea, {pasteAsPlainText})
+  return subscribe(textarea, {pasteLinkAsPlainTextOverSelectedText})
 }
 
 function paste(textarea, data) {


### PR DESCRIPTION
### Motive

We wish to be able to have granual control over specifically the behaviour of whether to linkify when pasting a link over selected text. This pull request extends the current code base to support granual config support on the installation of the package, at this time, it only adds one control being for the `paste-markdown-link` (urlLinks in our API params).

This config, which is default set to false (undefined | false), is the existing behaviour and therefore not a breaking change.

The approach would therefore add the following "new" behaviour, given the pasteLinkAsPlainTextOverSelectedText flag for `paste-markdown-link`, and depending on whether the skipFormattingFlag is on/off:

- paste plain text is on, no skip flag -> paste as plain
- paste plain text is on, skip flag -> try linkify
- paste plain text is off, no skip flag -> try linkify
- paste plain text is off, skip flag -> paste as plain

As we add future support, we should extend this down to the future classes + add tests, I do not believe it would be _much_ extra work but let's do it as a follow up or as a per-need basis.

### Drawbacks

End-users may see this optional config as misleading, as we are passing in the options params to all base paste classes but only have it supported in _one_ currently, but the documentation will reflect this.