### PR TITLE
Publish to GitHub Package Registry in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,6 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm --ignore-scripts publish
+      - run: npm whoami; npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
The `publish` workflow was skipping the [`postpublish` script](https://github.com/github/paste-markdown/blob/main/package.json#L17) that publishes this package to the GitHub Package Registry. This PR removes the `--ignore-scripts` flag in that workflow that was preventing the `postpublish` script from running