### PR TITLE
Independent publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,18 @@ jobs:
       - run: npm whoami; npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+  publish-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - run: npm whoami; npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'
+      - run: npm whoami; npm publish --@github:registry='https://npm.pkg.github.com'

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "build": "rollup -c",
     "pretest": "npm run build",
     "test": "karma start karma.config.js",
-    "prepublishOnly": "npm run build",
-    "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'"
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "clipboard",


### PR DESCRIPTION
Makes publishing to npm and github registry independent

Unlike before, If the [first one fails](https://github.com/github/paste-markdown/actions/runs/3178114867), it would not stop the second