### PR TITLE
Fix: Pasting of html with similar matches that have links

### DIFF
--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -66,6 +66,11 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
       ? (currentNode.textContent || '').replace(/[\t\n\r ]+/g, ' ')
       : (currentNode.firstChild as Text)?.wholeText || ''
 
+    // // update current index without link
+    if (!isLink(currentNode)) {
+      markdownIgnoreBeforeIndex += text.replace(/[\t\n\r ]+/g, ' ').trimStart().length
+    }
+
     // No need to transform whitespace
     if (isEmptyString(text)) {
       currentNode = walker.nextNode()
@@ -83,8 +88,6 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
         markdown =
           markdown.slice(0, markdownFoundIndex) + markdownLink + markdown.slice(markdownFoundIndex + text.length)
         markdownIgnoreBeforeIndex = markdownFoundIndex + markdownLink.length
-      } else {
-        markdownIgnoreBeforeIndex = markdownFoundIndex + text.length
       }
     }
 

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -66,7 +66,7 @@ function convertToMarkdown(plaintext: string, walker: TreeWalker): string {
       ? (currentNode.textContent || '').replace(/[\t\n\r ]+/g, ' ')
       : (currentNode.firstChild as Text)?.wholeText || ''
 
-    // // update current index without link
+    // update value of markdownIgnoreBeforeIndex with current index if the current node is not a link
     if (!isLink(currentNode)) {
       markdownIgnoreBeforeIndex += text.replace(/[\t\n\r ]+/g, ' ').trimStart().length
     }

--- a/test/test.js
+++ b/test/test.js
@@ -360,6 +360,30 @@ describe('paste-markdown', function () {
       paste(textarea, data)
       assert.include(textarea.value, tableMarkdown)
     })
+
+    it('pastes markdown with links correctly when identical labels are present', function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = `<meta charset='utf-8'><span>
+      foo bar baz <a href="https://www.abcxyz.com/">bar</a></span>`
+      const plaintextSentence = 'foo bar baz bar'
+      const markdownSentence = 'foo bar baz [bar](https://www.abcxyz.com/)'
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
+
+    it('pastes markdown with line breaks and links correctly when identical labels are present', function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = `<meta charset='utf-8'>
+      <p>foo bar
+          bar baz <a href="https://www.abcxyz.org/">bar</a> </p>
+          <p>baz <a href="https://www.abcxyz.com/">baz</a> foo</p>`
+      const plaintextSentence = 'foo bar bar baz bar baz baz foo'
+      const markdownSentence = 'foo bar bar baz [bar](https://www.abcxyz.org/) baz [baz](https://www.abcxyz.com/) foo'
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -384,6 +384,41 @@ describe('paste-markdown', function () {
       paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
       assert.equal(textarea.value, markdownSentence)
     })
+
+    it('pastes markdown with multiple links and labels correctly', function () {
+      // eslint-disable-next-line i18n-text/no-en
+      const commonSentence = 'Great example for example resources for developers'
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = `<meta charset='utf-8'><span>
+      ${commonSentence}: <a href="https://www.example.com/">example</a> and <a href="https://www.example.com/">example</a>.</span>`
+      const plaintextSentence = `${commonSentence}: example and example.`
+      const markdownSentence = `${commonSentence}: [example](https://www.example.com/) and [example](https://www.example.com/).`
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
+
+    it('pastes markdown with link labels that contains special characters in html', function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = `<meta charset='utf-8'>
+      <a href="https://www.abcxyz.org/">foo bar</a> <a href="https://example.com/?q=foo&bar=baz">foo&bar</a>`
+      const plaintextSentence = 'foo bar foo&bar'
+      const markdownSentence = '[foo bar](https://www.abcxyz.org/) [foo&bar](https://example.com/?q=foo&bar=baz)'
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
+
+    it('pastes markdown with link labels that contains emojis in html', function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const sentence = `<meta charset='utf-8'>
+      <p>foo bar <a href="https://www.abcxyz.org/">foo</a> bar foo <a href="https://example.com/">🚀 bar 🚀</a></p>`
+      const plaintextSentence = 'foo bar foo bar foo 🚀 bar 🚀'
+      const markdownSentence = 'foo bar [foo](https://www.abcxyz.org/) bar foo [🚀 bar 🚀](https://example.com/)'
+
+      paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
+      assert.equal(textarea.value, markdownSentence)
+    })
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -401,9 +401,10 @@ describe('paste-markdown', function () {
     it('pastes markdown with link labels that contains special characters in html', function () {
       // eslint-disable-next-line github/unescaped-html-literal
       const sentence = `<meta charset='utf-8'>
-      <a href="https://www.abcxyz.org/">foo bar</a> <a href="https://example.com/?q=foo&bar=baz">foo&bar</a>`
-      const plaintextSentence = 'foo bar foo&bar'
-      const markdownSentence = '[foo bar](https://www.abcxyz.org/) [foo&bar](https://example.com/?q=foo&bar=baz)'
+      <p>foo&bar <a href="https://www.abcxyz.org/">foo bar</a> <a href="https://example.com/?q=foo&bar=baz">foo&bar</a></p>`
+      const plaintextSentence = 'foo&bar foo bar foo&bar'
+      const markdownSentence =
+        'foo&bar [foo bar](https://www.abcxyz.org/) [foo&bar](https://example.com/?q=foo&bar=baz)'
 
       paste(textarea, {'text/html': sentence, 'text/plain': plaintextSentence})
       assert.equal(textarea.value, markdownSentence)


### PR DESCRIPTION
Hi 👋🏼, this is an attempt to fix the issue below where Pasting HTML with links can place the link in the wrong place

- https://github.com/github/issues/issues/5429

The [original fix was submitted here](https://github.com/github/paste-markdown/pull/50). This PR attempts to look at a few edge cases that came up as shown indicated in the issue above. These include:

> ```
> foo bar baz [bar](https://www.abcxyz.com)
> ```
> Which would result to the following after pasting
> ```
> foo [bar](https://www.abcxyz.com/) baz bar
> ```

and

> ```
> foo bar 
> bar baz [bar](https://www.abcxyz.org/) 
>  
> baz [baz](https://www.abcxyz.com/) foo
> ```
> 
> Which would result to the following after pasting
> ```
> foo bar
> [bar](https://www.abcxyz.org/) [baz](https://www.abcxyz.com/) bar
> 
> baz baz foo
> ```