### PR TITLE
Avoid ReDOS on table paste

### DIFF
--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -91,6 +91,12 @@ function generateText(transfer: DataTransfer): string | undefined {
   const html = transfer.getData('text/html')
   if (!/<table/i.test(html)) return
 
+  // eslint-disable-next-line github/unescaped-html-literal
+  const start = html.substring(0, html.indexOf('<table'))
+  const tableCloseIndex = html.lastIndexOf('</table>')
+  if (!start || !tableCloseIndex) return
+  const end = html.substring(tableCloseIndex + 8)
+
   const parser = new DOMParser()
   const parsedDocument = parser.parseFromString(html, 'text/html')
 
@@ -100,5 +106,7 @@ function generateText(transfer: DataTransfer): string | undefined {
 
   const formattedTable = tableMarkdown(table)
 
-  return html.replace(/<meta.*?>/, '').replace(/<table[.\S\s]*<\/table>/, `\n${formattedTable}`)
+  if (!formattedTable) return
+
+  return [start, formattedTable, end].join('').replace(/<meta.*?>/, '')
 }

--- a/test/test.js
+++ b/test/test.js
@@ -202,7 +202,7 @@ describe('paste-markdown', function () {
       assert.equal(
         textarea.value.trim(),
         // eslint-disable-next-line github/unescaped-html-literal
-        `<p>Here is a cool table</p>\n        \n  \n\n${tableMarkdown}\n\n\n\n        <p>Very cool</p>`
+        `<p>Here is a cool table</p>\n        \n  \n${tableMarkdown}\n\n\n\n        <p>Very cool</p>`
       )
     })
 
@@ -217,6 +217,19 @@ describe('paste-markdown', function () {
           </tbody>
         </table>
         `
+      }
+      paste(textarea, data)
+
+      // Synthetic paste events don't manipulate the DOM. A empty textarea
+      // means that the event handler didn't fire and normal paste happened.
+      assertUnformattedPaste(textarea)
+    })
+
+    it('rejects malformed tables', function () {
+      // eslint-disable-next-line github/unescaped-html-literal, prefer-template
+      const html = '<table'.repeat(999) + '<div><table></div>'
+      const data = {
+        'text/html': html
       }
       paste(textarea, data)
 


### PR DESCRIPTION
Resolves https://github.com/github/primer/issues/2532

This came in from a support escalation: it is possible to create a ReDOS crash on paste of a table with a (fairly contrived) clipboard contents. Thanks @P0cas for reporting this!

The crash is due to a [Catastrophic Backtracking](https://www.regular-expressions.info/catastrophic.html) regex in the `table` plugin, which is triggered by the following clipboard contents:

```js
example.oncopy = e => {
  e.preventDefault()
  const badTable = '<table'.repeat(99999) + '<div><table></div>'
  e.clipboardData.setData('text/html', badTable)
}
 ```

 While the problem is contrived the fix is fairly simple: rather than use a regex to insert the formatted table, we can just splice it in directly.