### PR TITLE
team mention pasting

### DIFF
--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -123,7 +123,7 @@ function linkify(element: HTMLAnchorElement, label: string): string {
   let markdown = ''
 
   // Don't linkify user mentions like "@octocat"
-  if (isUserMention(element)) {
+  if (isUserMention(element) || isTeamMention(element)) {
     markdown = label
     // Don't linkify things like "#123" or commit comparisons
   } else if (isSpecialLink(element) || areEqualLinks(url, label)) {
@@ -155,4 +155,9 @@ function areEqualLinks(link1: string, link2: string) {
 // User mentions have a "@" and a hovercard attribute of type "user"
 function isUserMention(link: HTMLAnchorElement): boolean {
   return link.textContent?.slice(0, 1) === '@' && link.getAttribute('data-hovercard-type') === 'user'
+}
+
+// Team mentions have a "@" and a hovercard attribute of type "team"
+function isTeamMention(link: HTMLAnchorElement): boolean {
+  return link.textContent?.slice(0, 1) === '@' && link.getAttribute('data-hovercard-type') === 'team'
 }

--- a/test/test.js
+++ b/test/test.js
@@ -320,6 +320,15 @@ describe('paste-markdown', function () {
       assert.equal(textarea.value, '')
     })
 
+    it("doesn't render any markdown for GitHub team handles", function () {
+      // eslint-disable-next-line github/unescaped-html-literal
+      const link = `<meta charset='utf-8'><a href="https://github.com/orgs/github/teams/octocats" data-hovercard-type="team">@github/octocats</a>`
+      const plaintextLink = '@github/octocats'
+
+      paste(textarea, {'text/html': link, 'text/plain': plaintextLink})
+      assert.equal(textarea.value, '')
+    })
+
     it('retains urls of special GitHub links', function () {
       const href = 'https://github.com/octocat/repo/issues/1'
       // eslint-disable-next-line github/unescaped-html-literal


### PR DESCRIPTION
related to https://github.com/github/html_pipeline/issues/76

This pull request to the codebase includes changes to improve the handling of GitHub team mentions in the `paste()` function. The most important changes include adding a new test case to check that team handles are not rendered as markdown, and updating the `linkify()` function to check if a link is a team mention using the new `isTeamMention()` function.

Main interface changes:

* <a href="diffhunk://#diff-c872021d2cf4d6e6c076e2589b1a7cb5ccf0a1e39f1e45c4734ba5897fbdd57dL126-R126">`src/paste-markdown-html.ts`</a>: Updated the `linkify()` function to check if a link is a team mention using the new `isTeamMention()` function, and returns the label as markdown if it is a team or user mention. <a href="diffhunk://#diff-c872021d2cf4d6e6c076e2589b1a7cb5ccf0a1e39f1e45c4734ba5897fbdd57dL126-R126">[1]</a> <a href="diffhunk://#diff-c872021d2cf4d6e6c076e2589b1a7cb5ccf0a1e39f1e45c4734ba5897fbdd57dR159-R163">[2]</a>

Testing improvements:

* <a href="diffhunk://#diff-a561630bb56b82342bc66697aee2ad96efddcbc9d150665abd6fb7ecb7c0ab2fR323-R331">`test/test.js`</a>: Added a new test case to check that team handles are not rendered as markdown in the `paste()` function.