### PR TITLE
add missing extensions to modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,9 @@
 {
   "root": true,
   "extends": ["plugin:github/browser", "plugin:github/recommended", "plugin:github/typescript"],
+  "rules": {
+    "import/no-unresolved": "off"
+  },
   "overrides": [
     {
       "files": "*.js",
@@ -11,7 +14,6 @@
       "files": "test/test.js",
       "rules": {
         "import/extensions": "off",
-        "import/no-unresolved": "off",
         "github/no-inner-html": "off",
         "eslint-comments/no-use": "off"
       }

--- a/examples/index.html
+++ b/examples/index.html
@@ -64,7 +64,7 @@
     <textarea cols="50" rows="10">The examples can be found here.</textarea>
 
     <script type="module">
-      import {subscribe} from '../dist/index.esm.js'
+      import {subscribe} from '../dist/index.js'
       // import {subscribe} from 'https://unpkg.com/@github/paste-markdown/dist/index.esm.js'
       subscribe(document.querySelector('textarea'))
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@open-wc/testing": "^4.0.0",
         "@web/dev-server-esbuild": "^1.0.2",
         "@web/test-runner": "^0.18.1",
-        "@web/test-runner-playwright": "^0.11.0",
         "esbuild": "^0.20.2",
         "eslint": "^8.57.0",
         "eslint-plugin-github": "^4.10.2",
@@ -2158,20 +2157,6 @@
       "dev": true,
       "dependencies": {
         "@web/test-runner-core": "^0.13.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@web/test-runner-playwright": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@web/test-runner-playwright/-/test-runner-playwright-0.11.0.tgz",
-      "integrity": "sha512-s+f43DSAcssKYVOD9SuzueUcctJdHzq1by45gAnSCKa9FQcaTbuYe8CzmxA21g+NcL5+ayo4z+MA9PO4H+PssQ==",
-      "dev": true,
-      "dependencies": {
-        "@web/test-runner-core": "^0.13.0",
-        "@web/test-runner-coverage-v8": "^0.8.0",
-        "playwright": "^1.22.2"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -6438,50 +6423,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.42.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
-import {install as installHTML, uninstall as uninstallHTML} from './paste-markdown-html'
-import {install as installImageLink, uninstall as uninstallImageLink} from './paste-markdown-image-link'
-import {install as installLink, uninstall as uninstallLink} from './paste-markdown-link'
+import {install as installHTML, uninstall as uninstallHTML} from './paste-markdown-html.js'
+import {install as installImageLink, uninstall as uninstallImageLink} from './paste-markdown-image-link.js'
+import {install as installLink, uninstall as uninstallLink} from './paste-markdown-link.js'
 import {
   installAround as installSkipFormatting,
   uninstall as uninstallSkipFormatting,
-} from './paste-keyboard-shortcut-helper'
-import {install as installTable, uninstall as uninstallTable} from './paste-markdown-table'
-import {install as installText, uninstall as uninstallText} from './paste-markdown-text'
+} from './paste-keyboard-shortcut-helper.js'
+import {install as installTable, uninstall as uninstallTable} from './paste-markdown-table.js'
+import {install as installText, uninstall as uninstallText} from './paste-markdown-text.js'
 import {OptionConfig} from './option-config'
 
 interface Subscription {

--- a/src/paste-keyboard-shortcut-helper.ts
+++ b/src/paste-keyboard-shortcut-helper.ts
@@ -1,4 +1,4 @@
-import {OptionConfig} from './option-config'
+import {OptionConfig} from './option-config.js'
 
 const skipFormattingMap = new WeakMap<HTMLElement, boolean>()
 

--- a/src/paste-markdown-html.ts
+++ b/src/paste-markdown-html.ts
@@ -1,5 +1,5 @@
-import {insertText} from './text'
-import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
+import {insertText} from './text.js'
+import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper.js'
 
 export function install(el: HTMLElement): void {
   el.addEventListener('paste', onPaste)

--- a/src/paste-markdown-image-link.ts
+++ b/src/paste-markdown-image-link.ts
@@ -1,6 +1,5 @@
-/* @flow strict */
-import {insertText} from './text'
-import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
+import {insertText} from './text.js'
+import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper.js'
 
 export function install(el: HTMLElement): void {
   el.addEventListener('dragover', onDragover)

--- a/src/paste-markdown-link.ts
+++ b/src/paste-markdown-link.ts
@@ -1,6 +1,6 @@
-import {OptionConfig} from './option-config'
-import {insertText} from './text'
-import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
+import {OptionConfig} from './option-config.js'
+import {insertText} from './text.js'
+import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper.js'
 
 const pasteLinkAsPlainTextOverSelectedTextMap = new WeakMap<HTMLElement, boolean>()
 

--- a/src/paste-markdown-table.ts
+++ b/src/paste-markdown-table.ts
@@ -1,5 +1,5 @@
-import {insertText} from './text'
-import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
+import {insertText} from './text.js'
+import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper.js'
 
 export function install(el: HTMLElement): void {
   el.addEventListener('dragover', onDragover)

--- a/src/paste-markdown-text.ts
+++ b/src/paste-markdown-text.ts
@@ -1,5 +1,5 @@
-import {insertText} from './text'
-import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper'
+import {insertText} from './text.js'
+import {shouldSkipFormatting} from './paste-keyboard-shortcut-helper.js'
 
 export function install(el: HTMLElement): void {
   el.addEventListener('paste', onPaste)


### PR DESCRIPTION
In https://github.com/github/paste-markdown/pull/97 we upgraded the module output, to output bare esm alongside the bundle. This was broken however, as the file extensions weren't added.

This PR adds those.